### PR TITLE
Add two azp template: init agent and debug agent

### DIFF
--- a/azure-pipelines/template-debugagent.yml
+++ b/azure-pipelines/template-debugagent.yml
@@ -1,0 +1,11 @@
+steps:
+- script: |
+    set -x
+    sudo df -h
+    sudo ls -al /
+    sudo ls -al /nfs
+    sudo ls -al /data
+    sudo getfacl /mnt /data
+    docker info
+  condition: always()
+  displayName: Debug agent issues

--- a/azure-pipelines/template-initagent.yml
+++ b/azure-pipelines/template-initagent.yml
@@ -1,0 +1,7 @@
+steps:
+- script: |
+    set -ex
+    if which init.sh;then
+      init.sh
+    fi
+  displayName: Init agent

--- a/azure-pipelines/template-showagent.yml
+++ b/azure-pipelines/template-showagent.yml
@@ -8,4 +8,4 @@ steps:
     sudo getfacl /mnt /data
     docker info
   condition: always()
-  displayName: Debug agent issues
+  displayName: Show agent state


### PR DESCRIPTION
Support 1ES migration. We will add an init.sh script into 1ES agent image.
When there is init.sh script, run it.