### PR TITLE
Add pipeline to auto upgrade submodule HEAD pointer.

### DIFF
--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -21,7 +21,7 @@ jobs:
     - checkout: none
     - bash: |
         set -ex
-        rm -rf sonic-buildimage
+        sudo rm -rf sonic-buildimage
         git clone https://github.com/sonic-net/sonic-buildimage
         cd sonic-buildimage
         git config user.email sonicbld@microsoft.com
@@ -66,6 +66,6 @@ jobs:
         body+="#### Description for the changelog"$'\n'
         git add .
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
-        git push mssonicbld HEAD:submodule-$(date +%F) -f
-        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "automerge" -b "$body" 2>&1
+        git push mssonicbld HEAD:submodule-${{ branch }}-$(date +%F) -f
+        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "automerge" -b "$body" 2>&1
       displayName: Update submodules

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -77,5 +77,5 @@ jobs:
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-${{ branch }}-$(date +%F) -f
         label="$(label)"
-        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "Submodule Update :arrow_double_up:,$label" -b "$body" 2>&1
+        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "Submodule Update :arrow_double_up:$label" -b "$body" 2>&1
       displayName: Update submodules

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -26,9 +26,9 @@ jobs:
         sudo rm -rf sonic-buildimage
         git clone https://github.com/sonic-net/sonic-buildimage
         cd sonic-buildimage
-        git config user.email sonicbld@microsoft.com
-        git config user.name mssonicbld
-        git config credential.https://github.com.username mssonicbld
+        git config user.email $(user_email)
+        git config user.name $(user_name)
+        git config credential.https://github.com.username $(user_name)
         git remote add mssonicbld https://mssonicbld:$TOKEN@github.com/mssonicbld/sonic-buildimage
         git checkout ${{ branch }}
         git fetch mssonicbld
@@ -53,7 +53,7 @@ jobs:
           cd $work_space/$path
           # 1. only keep repos in sonic-net organization
           git remote -vv | grep 'github.com/sonic-net/' || continue
-          # 2. only update master branch
+          # 2. only update the same branch with sonic-buildimage
           git branch -a --contains HEAD | grep 'remotes/origin/${{ branch }}' || continue
 
           head=$(git rev-parse HEAD)
@@ -76,6 +76,6 @@ jobs:
         git add .
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-${{ branch }}-$(date +%F) -f
-        label="$(label)"
-        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" $label -b "$body" 2>&1
+        pr_options="$(pr_options)"
+        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" $pr_options -b "$body" 2>&1
       displayName: Update submodules

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -31,6 +31,7 @@ jobs:
         git checkout ${{ branch }}
         git fetch mssonicbld
         git submodule update --init src/*
+        echo $TOKEN | gh auth login --with-token
       env:
         TOKEN: $(token)
     - bash: |
@@ -41,11 +42,9 @@ jobs:
         while read -r line
         do
           path=$(echo $line| awk '{print$2}')
-
           cd $work_space/$path
           # 1. only keep repos in sonic-net organization
           git remote -vv | grep 'github.com/sonic-net/' || continue
-
           # 2. only update master branch
           git branch -a --contains HEAD | grep 'remotes/origin/${{ branch }}' || continue
 
@@ -67,11 +66,4 @@ jobs:
         git add .
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-$(date +%F) -f
-
-        echo $TOKEN | gh auth login --with-token
-        result=$(gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -b "$body" 2>&1)
-        new_pr_rul=$(echo $result | grep github.com)
-        gh pr edit $new_pr_rul --add-label "automerge"
-      env:
-        TOKEN: $(token)
-
+        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "automerge" -b "$body" 2>&1

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -76,5 +76,6 @@ jobs:
         git add .
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-${{ branch }}-$(date +%F) -f
-        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "automerge" -b "$body" 2>&1
+        label="$(label)"
+        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" $label -b "$body" 2>&1
       displayName: Update submodules

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -45,6 +45,7 @@ jobs:
         while read -r line
         do
           path=$(echo $line| awk '{print$2}')
+          # if some modules break PR build. Add them to ignore_pathes
           for ignore_path in $(ignore_pathes)
           do
             if [[ "$ignore_path" == "$path" ]] && continue 2
@@ -67,6 +68,8 @@ jobs:
           fi
         done < <(git submodule status -- src/*)
         cd $work_space
+        # if no nothing changed, exit
+        git status | grep "nothing to commit, working tree clean" && exit 0
         body+="#### How I did it"$'\n'
         body+="#### How to verify it"$'\n'
         body+="#### Description for the changelog"$'\n'

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -37,7 +37,7 @@ jobs:
         set -ex
         cd sonic-buildimage
         work_space=$(pwd)
-        body=''
+        body="#### Why I did it"$'\n'
         while read -r line
         do
           path=$(echo $line| awk '{print$2}')
@@ -61,6 +61,9 @@ jobs:
           fi
         done < <(git submodule status -- src/*)
         cd $work_space
+        body+="#### How I did it"$'\n'
+        body+="#### How to verify it"$'\n'
+        body+="#### Description for the changelog"$'\n'
         git add .
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-$(date +%F) -f

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -1,0 +1,74 @@
+pr: none
+trigger: none
+schedules:
+- cron: "1 1 * * *"
+  displayName: Daily build
+  branches:
+    include:
+      - master
+
+parameters:
+- name: branches
+  type: object
+  default:
+  - master
+
+jobs:
+- ${{ each branch in parameters.branches }}:
+  - job:
+    displayName: ${{ branch }}
+    steps:
+    - checkout: none
+    - bash: |
+        set -ex
+        rm -rf sonic-buildimage
+        git clone https://github.com/sonic-net/sonic-buildimage
+        cd sonic-buildimage
+        git config user.email sonicbld@microsoft.com
+        git config user.name mssonicbld
+        git config credential.https://github.com.username mssonicbld
+        git remote add mssonicbld https://mssonicbld:$TOKEN@github.com/mssonicbld/sonic-buildimage
+        git checkout ${{ branch }}
+        git fetch mssonicbld
+        git submodule update --init src/*
+      env:
+        TOKEN: $(token)
+    - bash: |
+        set -ex
+        cd sonic-buildimage
+        work_space=$(pwd)
+        body=''
+        while read -r line
+        do
+          path=$(echo $line| awk '{print$2}')
+
+          cd $work_space/$path
+          # 1. only keep repos in sonic-net organization
+          git remote -vv | grep 'github.com/sonic-net/' || continue
+
+          # 2. only update master branch
+          git branch -a --contains HEAD | grep 'remotes/origin/${{ branch }}' || continue
+
+          head=$(git rev-parse HEAD)
+          git checkout ${{ branch }}
+          git pull
+          commits=$(git log ${head}..HEAD --pretty=reference)
+          if [[ "$commits" != "" ]];then
+            body+="$path"$'\n'
+            body+='```'$'\n'
+            body+=$commits$'\n'
+            body+='```'$'\n'
+          fi
+        done < <(git submodule status -- src/*)
+        cd $work_space
+        git add .
+        git commit -m "[submodule] Update submodule to the latest HEAD automatically"
+        git push mssonicbld HEAD:submodule-$(date +%F) -f
+
+        echo $TOKEN | gh auth login --with-token
+        result=$(gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -b "$body" 2>&1)
+        new_pr_rul=$(echo $result | grep github.com)
+        gh pr edit $new_pr_rul --add-label "automerge"
+      env:
+        TOKEN: $(token)
+

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -77,5 +77,5 @@ jobs:
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-${{ branch }}-$(date +%F) -f
         label="$(label)"
-        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "Submodule Update,$label" -b "$body" 2>&1
+        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "Submodule Update :arrow_double_up:,$label" -b "$body" 2>&1
       displayName: Update submodules

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -1,7 +1,7 @@
 pr: none
 trigger: none
 schedules:
-- cron: "1 1 * * *"
+- cron: "19 1 * * *"
   displayName: Daily build
   branches:
     include:
@@ -12,6 +12,8 @@ parameters:
   type: object
   default:
   - master
+  - 202211
+  - 202205
 
 jobs:
 - ${{ each branch in parameters.branches }}:
@@ -43,6 +45,10 @@ jobs:
         while read -r line
         do
           path=$(echo $line| awk '{print$2}')
+          for ignore_path in $(ignore_pathes)
+          do
+            if [[ "$ignore_path" == "$path" ]] && continue 2
+          done
           cd $work_space/$path
           # 1. only keep repos in sonic-net organization
           git remote -vv | grep 'github.com/sonic-net/' || continue

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -48,7 +48,7 @@ jobs:
           # if some modules break PR build. Add them to ignore_pathes
           for ignore_path in $(ignore_pathes)
           do
-            if [[ "$ignore_path" == "$path" ]] && continue 2
+            [[ "$ignore_path" == "$path" ]] && continue 2
           done
           cd $work_space/$path
           # 1. only keep repos in sonic-net organization

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -76,6 +76,6 @@ jobs:
         git add .
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-${{ branch }}-$(date +%F) -f
-        pr_options="$(pr_options)"
-        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" $pr_options -b "$body" 2>&1
+        label="$(label)"
+        gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-${{ branch }}-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "Submodule Update,$label" -b "$body" 2>&1
       displayName: Update submodules

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -34,8 +34,9 @@ jobs:
         echo $TOKEN | gh auth login --with-token
       env:
         TOKEN: $(token)
+      displayName: Setup env
     - bash: |
-        set -ex
+        set -e
         cd sonic-buildimage
         work_space=$(pwd)
         body="#### Why I did it"$'\n'
@@ -67,3 +68,4 @@ jobs:
         git commit -m "[submodule] Update submodule to the latest HEAD automatically"
         git push mssonicbld HEAD:submodule-$(date +%F) -f
         gh pr create -R sonic-net/sonic-buildimage -H mssonicbld:submodule-$(date +%F) -B ${{ branch }} -t "[submodule] Update submodule to the latest HEAD automatically" -l "automerge" -b "$body" 2>&1
+      displayName: Update submodules


### PR DESCRIPTION
Auto upgrade sonic-buildimage submodule pointer and create a PR. When PR validation passed, auto merge that PR.
It works for submodules which meet all three limits:
1. submodule path under folder 'src/'
2. submodule's branch is same as sonic-buildimage's branch
3. submodule repo belongs to github.com/sonic-net.

sample PR:
https://github.com/sonic-net/sonic-buildimage/pull/13622