### PR TITLE
Update acr-clean.yml for Azure Pipelines

### DIFF
--- a/azure-pipelines/acr-clean.yml
+++ b/azure-pipelines/acr-clean.yml
@@ -24,6 +24,7 @@ jobs:
           set -ex
 
           az login --identity
+          az account set --subscription 9355ef17-3aa2-493a-94ab-a43a9bf8cd70
           az acr show -n sonicdev
           sudo apt-get update
           sudo apt install -y jq


### PR DESCRIPTION
When az login, it has two subscriptions. A random one will be select as default.
If it select the wrong subscription, pipeline will fail. Now we specify the subscription to avoid this issue.
Pipeline link: https://dev.azure.com/mssonic/build/_build?definitionId=1401&_a=summary