### PR TITLE
[sync docker] Delete variable group sonicbld and improve az cli installation

### DIFF
--- a/azure-pipelines/sync-docker-image.yml
+++ b/azure-pipelines/sync-docker-image.yml
@@ -18,12 +18,22 @@ jobs:
   - job: Build
     pool: sonic-ubuntu-1c
     timeoutInMinutes: 20
-    variables:
-      - group: sonicbld
     steps:
       - checkout: self
         clean: true
-      - script: |
+          # Wait for apt lock to be released (timeout after 10 minutes)
+          timeout=600
+          elapsed=0
+          while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || sudo fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
+            if [ $elapsed -ge $timeout ]; then
+              echo "Timeout waiting for apt lock after 10 minutes"
+              exit 1
+            fi
+            echo "Waiting for apt lock to be released..."
+            sleep 5
+            elapsed=$((elapsed + 5))
+          done
+
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
         displayName: install dependencies
       - ${{ each platform in parameters.platforms }}:


### PR DESCRIPTION
1. The sonicbld variable group is not required by this pipeline. Delete it. 
2. Add code to wait for the apt lock before installing azure cli to avoid the azure cli installation failure.