### PR TITLE
[submodule update msft] Delete reference of unused token

### DIFF
--- a/azure-pipelines/submodule-update-msft.yml
+++ b/azure-pipelines/submodule-update-msft.yml
@@ -16,7 +16,6 @@ steps:
       git config --global user.name "Sonic Automation"
       git config --global pull.rebase false
       echo $TOKEN | gh auth login --with-token
-      echo $AZURE_DEVOPS_EXT_PAT | az devops login
 
       sudo rm -rf sonic-buildimage-msft
       git clone https://github.com/Azure/sonic-buildimage-msft
@@ -25,7 +24,6 @@ steps:
       git fetch mssonicbld
     env:
       TOKEN: $(GITHUB-TOKEN)
-      AZURE_DEVOPS_EXT_PAT: $(MSAZURE-TOKEN)
     displayName: Setup env
   - bash: |
       set -ex


### PR DESCRIPTION
The MSAZURE-TOKEN is not really being used. And there is plan to deprecate this token. This change deleted the reference of MSAZURE-TOKEN in the pipeline yaml file.