### PR TITLE
add platform/vpp submodule to auto ref update pipeline

### DIFF
--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -38,7 +38,7 @@ jobs:
         git remote add mssonicbld https://mssonicbld:$TOKEN@github.com/mssonicbld/sonic-buildimage
         git checkout ${{ branch }}
         git fetch mssonicbld
-        git submodule update --init src/*
+        git submodule update --init src/* platform/vpp
         echo $TOKEN | gh auth login --with-token
       env:
         TOKEN: $(GITHUB-TOKEN)
@@ -118,5 +118,5 @@ jobs:
             git reset HEAD~ --hard
             sleep $(INTERVAL)
           fi
-        done < <(git submodule status -- src/*)
+        done < <(git submodule status -- src/* platform/vpp)
       displayName: Update submodules

--- a/azure-pipelines/submodule-update.yml
+++ b/azure-pipelines/submodule-update.yml
@@ -38,7 +38,7 @@ jobs:
         git remote add mssonicbld https://mssonicbld:$TOKEN@github.com/mssonicbld/sonic-buildimage
         git checkout ${{ branch }}
         git fetch mssonicbld
-        git submodule update --init src/* platform/vpp
+        git submodule update --init src/* $(if git config -f .gitmodules --get submodule.platform/vpp.url &>/dev/null; then echo platform/vpp; fi)
         echo $TOKEN | gh auth login --with-token
       env:
         TOKEN: $(GITHUB-TOKEN)
@@ -118,5 +118,5 @@ jobs:
             git reset HEAD~ --hard
             sleep $(INTERVAL)
           fi
-        done < <(git submodule status -- src/* platform/vpp)
+        done < <(git submodule status -- src/* $(if git config -f .gitmodules --get submodule.platform/vpp.url &>/dev/null; then echo platform/vpp; fi))
       displayName: Update submodules


### PR DESCRIPTION
add platform/vpp submodule to auto ref update pipeline

Two changes made to [submodule-update.yml](vscode-file://vscode-app/c:/Users/zhangjing/AppData/Local/Programs/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html):

[Line 42](vscode-file://vscode-app/c:/Users/zhangjing/AppData/Local/Programs/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — git submodule update --init now also initializes platform/vpp in addition to src/*.
[Line 123](vscode-file://vscode-app/c:/Users/zhangjing/AppData/Local/Programs/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — The iteration loop (git submodule status) now includes platform/vpp so the automation will detect new commits and create update PRs for it.
The existing module_name derivation (sed 's#src/##') will pass platform/vpp through unchanged (since there's no src/ prefix to strip), producing branch names like submodule-master-platform/vpp and PR titles like [submodule][master] Update submodule platform/vpp to the latest HEAD automatically, which is appropriate.

sign-off: Jing Zhang zhangjing@microsoft.com 