### PR TITLE
[ci] Improve PR scan stability for sonic-mgmt by avoiding heavy list payloads

### DIFF
--- a/azure-pipelines/automation-pr-scan.yml
+++ b/azure-pipelines/automation-pr-scan.yml
@@ -42,7 +42,7 @@ jobs:
         # failed after retry, comment release branch owner and original PR author to check
         date_3d_ago=$(date --date "3 day ago" -u +"%FT%TZ")
         date_15d_ago=$(date --date "15 day ago" -u +"%FT%TZ")
-        date_1m_ago=$(date --date "1 month ago" -u +"%FT%TZ")
+        date_1m_ago_q=$(date --date "1 month ago" -u +"%Y-%m-%d")
         date_now=$(date -u +"%T")
         operate=false
         [[ "$date_now" > "22:00:00" ]] && operate=true
@@ -61,13 +61,13 @@ jobs:
             echo ======== working for $repo ========
             echo $repo >> failure_prs.log
             merge_op=true
-            if $repo == "sonic-net/sonic-mgmt"; then
+            if [[ $repo == "sonic-net/sonic-mgmt" ]]; then
               # For sonic-mgmt repo, it has its own github workflow to merge the cherry pick PR
               merge_op=false
             fi
-            automerge_prs=$(gh pr list -A mssonicbld --label automerge -R $repo -L 100 --json body,title,url,labels,statusCheckRollup,createdAt,baseRefName,comments)
-            upgrade_versions_prs=$(gh pr list -A mssonicbld -R $repo -L 100 --search '"Upgrade SONiC package Versions" in:title' --json body,title,url,labels,statusCheckRollup,createdAt,baseRefName,comments)
-            prs=$(jq -sc --arg date_1m_ago "$date_1m_ago" 'add | unique_by(.url) | map(select(.createdAt >= $date_1m_ago))' <(echo "$automerge_prs") <(echo "$upgrade_versions_prs"))
+            automerge_prs=$(gh pr list -A mssonicbld --label automerge -R $repo -L 100 --search "created:>=$date_1m_ago_q" --json body,title,url,labels,statusCheckRollup,createdAt,baseRefName,comments)
+            upgrade_versions_prs=$(gh pr list -A mssonicbld -R $repo -L 100 --search "\"Upgrade SONiC package Versions\" in:title created:>=$date_1m_ago_q" --json body,title,url,labels,statusCheckRollup,createdAt,baseRefName,comments)
+            prs=$(jq -sc 'add | unique_by(.url)' <(echo "$automerge_prs") <(echo "$upgrade_versions_prs"))
             c=$(echo $prs | jq length)
             for ((i=0; i<$c; i++)); do
               set +x
@@ -130,8 +130,9 @@ jobs:
                   echo "    Commented to retry." >> skip_prs.log
                 fi
                 if [ -n "$origin_pr_url" ] && [[ $created_at < $date_3d_ago ]] && $retried && $sonic_build_failure; then
-                  author=$(gh pr view $origin_pr_url --json author | jq .author.login -r)
-                  origin_comments=$(gh pr view $origin_pr_url --json comments | jq .comments)
+                  origin_pr_detail=$(gh pr view $origin_pr_url --json author,comments)
+                  author=$(echo $origin_pr_detail | jq .author.login -r)
+                  origin_comments=$(echo $origin_pr_detail | jq .comments)
                   release_owner_key=$(echo "$base_ref" | sed -E 's/^msft-//' | grep -Eo '[0-9]{6}' | head -n1 || true)
                   release_owner=$(echo "$release_owners" | jq -r --arg release_owner_key "$release_owner_key" '.[$release_owner_key] // empty')
                   if ! echo "$origin_comments" | jq -e '.[]? | select(((.author.login // "") == "mssonicbld") and ((.body // "") | test("cherry pick PR didn.t pass PR checker after retry"; "i")))' > /dev/null; then
@@ -188,6 +189,10 @@ jobs:
         repos="${{ parameters.repos }}"
         release_owners=$(cat azure-pipelines/release-owners_github_account.json)
         for repo in $repos $(EXTRA_REPOS); do
+          if [[ $repo == "sonic-net/sonic-mgmt" ]]; then
+            # For sonic-mgmt repo, it has its own github workflow
+            continue
+          fi
           echo ======== working for $repo ========
           echo "=======Results for $repo======" >> label_scan.log
           prs=$(gh pr list -R $repo --state merged -L 200 --json url,labels,mergedAt,author,comments | jq -c --arg one_week_ago "$one_week_ago" '[.[] | select(.mergedAt >= $one_week_ago and ((.author.login // "") != "mssonicbld"))]')


### PR DESCRIPTION
The auto PR scan failed on sonic-mgmt consistently with the following error:
`HTTP 504: We couldn't respond to your request in time. Sorry about that. Please try resubmitting your request and contact us if the problem persists. (https://api.github.com/graphql)`
This change
- Fixes intermittent failures when scanning sonic-mgmt PRs in automation.
- Reduces GitHub API pressure by changing how PR data is fetched.