### PR TITLE
[ci] skip sending cherry-pick PR not created notification for submodule update PRs

### DIFF
--- a/azure-pipelines/automation-pr-scan.yml
+++ b/azure-pipelines/automation-pr-scan.yml
@@ -236,6 +236,10 @@ jobs:
                 continue
               fi
               if ! echo "$comments" | jq -e --arg base_branch "$base_branch" '.[]? | select(((.author.login // "") == "mssonicbld") and ((.body // "") | test("Cherry-pick PR to " + $base_branch; "i")))' > /dev/null; then
+                if echo "$comments" | jq -e '.[]? | select(((.author.login // "") == "mssonicbld") and ((.body // "") | test("submodule update. Please manually cherry pick!"; "i")))' > /dev/null; then
+                  echo "submodule update detected, skip for $url" >> label_scan.log
+                  continue
+                fi
                 if echo "$comments" | jq -e '.[]? | select(((.author.login // "") == "mssonicbld") and ((.body // "") | test("Removing approved label and adding it again to trigger cherry pick workflow"; "i")))' > /dev/null; then
                   comment_pr "$url" "Cherry pick PR is not created after readding the approved label. @yijingyan2, please help check if the cherry pick workflow is working. Thanks!"
                   echo "Commented to let yijingyan2 check cherry pick workflow for $url" >> label_scan.log


### PR DESCRIPTION
#### Why I did it
In `automation-pr-scan.yml`, when a cherry-pick PR is not created, the scan pings a maintainer to check the cherry-pick workflow. However, auto cherry-pick does not support submodule update PRs — the bot already comments
"Auto cherry pick don't support submodule update. Please manually cherry pick!" on those PRs. The follow-up "PR not created" notification is therefore a false alarm and creates noise for maintainers.

#### How I did it
Before sending the "cherry-pick PR not created" notification, check the PR comments for the bot's existing "submodule update not supported" message. If present, log it to `label_scan.log` and skip (continue) instead of pinging the maintainer.

#### How to verify it
- On a submodule update PR where auto cherry-pick left the "don't support submodule update" comment and no cherry-pick PR exists: confirm no maintainer ping is posted and `label_scan.log` shows "submodule update detected, skip for <url>".
- On a normal PR with no cherry-pick PR: confirm the existing notification behavior is unchanged.