### PR TITLE
fix apt-get upgrade hanging issue

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -2,17 +2,37 @@
 
 set -ex
 
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+export NEEDRESTART_SUSPEND=1
+
+apt-get -y purge --auto-remove needrestart || true
+apt-mark hold needrestart || true
+ 
+mkdir -p /etc/needrestart/conf.d
+cat > /etc/needrestart/conf.d/99-no-prompt.conf <<'EOF'
+$nrconf{restart} = 'a';
+$nrconf{kernelhints} = 0;
+$nrconf{ucodehints} = 0;
+EOF
+
 ARCH=$1
 DEFAULT_ARCH=$(dpkg --print-architecture)
 [ -z "$ARCH" ] && [ -f /etc/docker-arch ] && ARCH=$(cat /etc/docker-arch)
-[ -z "$ARCH" ] && ARCH=$DEFAULT_ARCH  
+[ -z "$ARCH" ] && ARCH=$DEFAULT_ARCH
 
 apt-get update
-NEEDRESTART_MODE=l DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y upgrade
+apt-get -y purge needrestart || true
+NEEDRESTART_MODE=l DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y dist-upgrade
 apt-get install -y ca-certificates curl gnupg lsb-release
+
+apt-get update
+apt-get install -y acl
+
 # install git lfs
 curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
-apt-get install -y git-lfs acl
+apt-get update
+apt-get install -y git-lfs
 
 if [ "$ARCH" == "armhf" ] && [ "$ARCH" != "$DEFAULT_ARCH" ]; then
   dpkg --add-architecture armhf
@@ -62,3 +82,8 @@ cat /etc/passwd /etc/group || true
 # Install build tools (and waiting docker ready)
 apt-get install -y build-essential nfs-common python3-pip python3-setuptools python3-pip python-is-python3
 pip3 install jinja2 j2cli markupsafe
+
+if [ -f /var/run/reboot-required ]; then
+   echo "Kernel/libs upgraded — rebooting"
+   systemctl reboot
+ fi


### PR DESCRIPTION
#### Why I did it

`apt-get upgrade` was hanging during provisioning. The hang is caused by `needrestart` (and interactive service-restart / kernel prompts) blocking the upgrade on a non-interactive CI agent, waiting for input that never comes.

#### How I did it

In `scripts/provision.sh`:

- Force fully non-interactive behavior by exporting `DEBIAN_FRONTEND=noninteractive`, `NEEDRESTART_MODE=a`, and `NEEDRESTART_SUSPEND=1`.
- Remove/hold `needrestart` (`apt-get purge --auto-remove needrestart`, `apt-mark hold needrestart`) and drop in `/etc/needrestart/conf.d/99-no-prompt.conf` to auto-restart services and suppress kernel/microcode hints, so no prompt is shown.
- Purge `needrestart` before the upgrade and switch `apt-get upgrade` to `dist-upgrade` (with `--force-confdef`/`--force-confold`) for a clean, prompt-free upgrade.
- Split the package installs so each runs after its own `apt-get update` (install `acl`, then add the git-lfs repo and install `git-lfs`).
- Reboot the agent when `/var/run/reboot-required` is present, so kernel/library upgrades take effect.

#### How to verify it

- Run the provisioning pipeline / `scripts/provision.sh` on a fresh agent and confirm it completes without hanging on the upgrade step.
- Confirm no interactive `needrestart`/service-restart prompt appears in the logs.
- Confirm required packages (`acl`, `git-lfs`, build tools) are installed and the agent reboots only when `reboot-required` is set.
