### PR TITLE
[agent provisioning] use uv instead of pip to install Python build dependencies

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -81,7 +81,10 @@ cat /etc/passwd /etc/group || true
 
 # Install build tools (and waiting docker ready)
 apt-get install -y build-essential nfs-common python3-pip python3-setuptools python3-pip python-is-python3
-pip3 install jinja2 j2cli markupsafe
+
+# Install uv (system-wide) and use it to install Python packages without pip
+curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+uv pip install --system jinja2 j2cli markupsafe
 
 if [ -f /var/run/reboot-required ]; then
    echo "Kernel/libs upgraded — rebooting"


### PR DESCRIPTION
## Summary
Switches provisioning from `pip3` to `uv` for installing the Python build dependencies, so we no longer rely on `pip3 install` at provision time.

## Why
- `python3-pip` triggers S360 security alerts and needs to be upgrade to a version that is only available in ubuntu pro.
- `uv` ships its own resolver/installer, so packages can be installed without pip.

## Changes (scripts/provision.sh)
- Install `uv` system-wide into `/usr/local/bin`.
- Install `jinja2`, `j2cli`, `markupsafe` via `uv pip install --system`.

## Follow-up
- Drop `python3-pip` from the apt install list once no pipeline depends on it.