### PR TITLE
Add sonic-linux-kernel to codesync for 202512 branch

### DIFF
--- a/azure-pipelines/codesync.json
+++ b/azure-pipelines/codesync.json
@@ -6,7 +6,7 @@
     "202412": "src/sonic-utilities src/sonic-swss src/sonic-platform-common src/sonic-platform-daemons src/sonic-sairedis src/sonic-linux-kernel src/sonic-swss-common src/sonic-gnmi",
     "202503": "src/sonic-utilities src/sonic-swss src/sonic-platform-common src/sonic-platform-daemons src/sonic-sairedis src/sonic-linux-kernel",
     "202506": "src/sonic-utilities src/sonic-swss src/sonic-platform-common src/sonic-platform-daemons src/sonic-sairedis src/sonic-swss-common src/sonic-dash-api src/sonic-dash-ha src/sonic-host-services src/sonic-gnmi",
-    "202512": "src/sonic-utilities",
+    "202512": "src/sonic-utilities src/sonic-linux-kernel",
     "202603": "src/sonic-utilities src/sonic-sairedis",
     "202511_azd": "src/sonic-gnmi src/sonic-swss src/sonic-swss-common src/sonic-utilities",
     "202606": "src/sonic-swss src/sonic-swss-common src/sonic-utilities src/sonic-linux-kernel",


### PR DESCRIPTION
### Description of PR
Add `src/sonic-linux-kernel` to the codesync list for the `202512` branch in `azure-pipelines/codesync.json`.

The `202512` entry currently only lists `src/sonic-utilities`, unlike other active release branches (202503, 202601, 202606, 202608) which already include `src/sonic-linux-kernel`. This enables the codesync pipeline to sync sonic-linux-kernel changes for 202512, consistent with the ongoing effort to keep `Azure/sonic-linux-kernel.msft:202512` in sync with `sonic-net/sonic-linux-kernel:202511` (see Azure/sonic-linux-kernel.msft#64 and Azure/sonic-buildimage-msft#2604).

### Type of change
- [x] Testbed and Framework(new/improvement)

### Approach
#### What is the motivation for this PR?
Enable automated code-sync for sonic-linux-kernel on the 202512 branch, matching the pattern used for other active release branches.

#### How did you do it?
Added `src/sonic-linux-kernel` to the `"202512"` entry in `azure-pipelines/codesync.json`.

#### How did you verify/test it?
Validated the JSON file parses correctly after the change; confirmed the diff is limited to the single `202512` line.
