### PR TITLE
fix: fetch branch objects before git reset in auto-cherry-pick

### DIFF
--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -34,6 +34,7 @@ check_conflict(){
         newpr_base="$ORG/$REPO"
     fi
     git remote update
+    git fetch head $PR_BASE_BRANCH --depth=100
     git status
     git checkout -b $PR_BASE_BRANCH --track head/$PR_BASE_BRANCH
     git status


### PR DESCRIPTION
## Why I did it

`git remote update` fetches remote refs (branch pointers) but does not guarantee the commit objects are present locally. For `msft-202607`, `PR_COMMIT_SHA` is a commit on `head/master`, but after only `git remote update` the objects may not be fetched, causing:

```
fatal: Could not parse object 'd75f39761dc5e92c615f5a4a278bbb0e76fc7218'.
```

## How I did it

Add an explicit `git fetch head $PR_BASE_BRANCH --depth=100` after `git remote update` in `check_conflict()` to ensure the commit objects are present before `git reset $PR_COMMIT_SHA --hard`.

## How to verify it

Re-run the auto-cherry-pick job for a PR targeting `msft-202607`; the `git reset` step should no longer fail with `Could not parse object`.