### PR TITLE
fix: fetch PR_COMMIT_SHA before git reset in auto-cherry-pick

### DIFF
--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -39,6 +39,9 @@ check_conflict(){
     git status
     contains_submodule=""
     if [[ "$PR_MERGED" == "true" ]];then
+        # PR_COMMIT_SHA is the squash/merge commit on master. Fetch it directly
+        # so git reset can resolve it regardless of how far master has moved on.
+        git fetch head $PR_COMMIT_SHA
         git reset $PR_COMMIT_SHA --hard
         if git show HEAD | grep -Eo "^\+Subproject commit "; then
             contains_submodule="true"


### PR DESCRIPTION
## Why I did it

`git remote update` fetches remote ref pointers but not the actual commit objects. For squash-merged PRs, `PR_COMMIT_SHA` is the real squash commit on master, but if master has moved on, that object may not be locally present after a shallow/partial fetch, causing:

```
fatal: Could not parse object 'd75f39761dc5e92c615f5a4a278bbb0e76fc7218'.
Exit Code: 128
```

## How I did it

Add `git fetch head $PR_COMMIT_SHA` before `git reset $PR_COMMIT_SHA --hard` to explicitly fetch that commit object from GitHub, regardless of how far master has moved on.

## How to verify it

Re-run the auto-cherry-pick job for a squash-merged PR targeting `msft-202607`; the `git reset` step should no longer fail with `Could not parse object`.