### PR TITLE
Revert "fix: fetch PR_COMMIT_SHA before git reset in auto-cherry-pick"

### DIFF
--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -40,9 +40,6 @@ check_conflict(){
     git status
     contains_submodule=""
     if [[ "$PR_MERGED" == "true" ]];then
-        # PR_COMMIT_SHA is the squash/merge commit on master. Fetch it directly
-        # so git reset can resolve it regardless of how far master has moved on.
-        git fetch head $PR_COMMIT_SHA
         git reset $PR_COMMIT_SHA --hard
         if git show HEAD | grep -Eo "^\+Subproject commit "; then
             contains_submodule="true"


### PR DESCRIPTION
Reverts sonic-net/sonic-pipelines#186