### PR TITLE
[ci] fix: fetch branch objects before git reset in auto-cherry-pick

### DIFF
--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -39,7 +39,12 @@ check_conflict(){
     git status
     contains_submodule=""
     if [[ "$PR_MERGED" == "true" ]];then
-        git reset $PR_COMMIT_SHA --hard
+        # PR_COMMIT_SHA from the webhook (merge_commit_sha) is GitHub's ephemeral
+        # test-merge object, which is deleted after a squash merge. Fetch the real
+        # post-merge commit from the GitHub API instead.
+        REAL_SHA=$(gh api repos/$ORG/$REPO/pulls/$PR_NUMBER --jq .merge_commit_sha)
+        git fetch head $REAL_SHA
+        git reset $REAL_SHA --hard
         if git show HEAD | grep -Eo "^\+Subproject commit "; then
             contains_submodule="true"
         fi


### PR DESCRIPTION
### Problem

In the auto-cherry-pick flow, when a PR is already merged (`PR_MERGED == "true"`), the script resets the working tree to `PR_COMMIT_SHA` (taken from the webhook payload's `merge_commit_sha`):

```sh
git reset $PR_COMMIT_SHA --hard
```

For a **squash-merged** PR, the `merge_commit_sha` carried by the webhook is GitHub's *ephemeral test-merge* object. GitHub deletes that object once the PR is squash-merged, so it no longer exists in the repository. When the script then tries to `git reset` onto it, git fails with an error such as `Could not parse object` / `unknown revision`, and the auto cherry-pick aborts.

### Fix

Resolve the **real** post-merge commit from the GitHub API (`pulls/{number}.merge_commit_sha`), fetch that object explicitly, and reset onto it:

```sh
# PR_COMMIT_SHA from the webhook (merge_commit_sha) is GitHub's ephemeral
# test-merge object, which is deleted after a squash merge. Fetch the real
# post-merge commit from the GitHub API instead.
REAL_SHA=$(gh api repos/$ORG/$REPO/pulls/$PR_NUMBER --jq .merge_commit_sha)
git fetch head $REAL_SHA
git reset $REAL_SHA --hard
```

The API returns the actual merge commit that lives on the base branch, and the explicit `git fetch head $REAL_SHA` guarantees the commit objects are present locally before `git reset`.

### Impact

- Fixes auto cherry-pick failures for squash-merged PRs.
- Behavior for non-merged PRs (the `else` branch) is unchanged.

### Files changed

- `azure-pipelines/auto-cherry-pick.sh`
