### PR TITLE
[ci] auto cherry-pick refine

### DIFF
--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -37,13 +37,21 @@ check_conflict(){
     git status
     git checkout -b $PR_BASE_BRANCH --track head/$PR_BASE_BRANCH
     git status
+    contains_submodule=""
     if [[ "$PR_MERGED" == "true" ]];then
         git reset $PR_COMMIT_SHA --hard
+        contains_submodule=$(git show HEAD | grep -Eo "^\+Subproject commit ")
         git reset HEAD~
         git add . -f
     else
         git fetch head +refs/pull/$PR_NUMBER/merge:refs/remotes/pull/$PR_NUMBER/merge
+        contains_submodule=$(git log head/$PR_BASE_BRANCH..$PR_COMMIT_SHA -p | grep -Eo "^\+Subproject commit ")
         git merge pull/$PR_NUMBER/merge --squash || { echo "PR is Out of Date!"; return 253; }
+    fi
+    if [ -n "$contains_submodule" ]; then
+        echo "PR contains submodule change"
+        gh pr comment $PR_URL --body "Auto cherry pick don't support submodule update. Please manually cherry pick!"
+        return 251
     fi
     content=$(gh pr view $PR_URL --json title,body)
     title=$(echo "$content" | jq .title -r)

--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -34,12 +34,18 @@ check_conflict(){
         newpr_base="$ORG/$REPO"
     fi
     git remote update
+    git fetch head $PR_BASE_BRANCH --depth=100
     git status
     git checkout -b $PR_BASE_BRANCH --track head/$PR_BASE_BRANCH
     git status
     contains_submodule=""
     if [[ "$PR_MERGED" == "true" ]];then
-        git reset $PR_COMMIT_SHA --hard
+        # PR_COMMIT_SHA from the webhook (merge_commit_sha) is GitHub's ephemeral
+        # test-merge object, which is deleted after a squash merge. Fetch the real
+        # post-merge commit from the GitHub API instead.
+        REAL_SHA=$(gh api repos/$ORG/$REPO/pulls/$PR_NUMBER --jq .merge_commit_sha)
+        git fetch head $REAL_SHA
+        git reset $REAL_SHA --hard
         if git show HEAD | grep -Eo "^\+Subproject commit "; then
             contains_submodule="true"
         fi

--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -60,7 +60,7 @@ check_conflict(){
     fi
     if [ -n "$contains_submodule" ]; then
         echo "PR contains submodule change"
-        gh pr comment $PR_URL --body "Auto cherry pick don't support submodule update. Please manually cherry pick!"
+        gh pr comment $PR_URL --body "Auto cherry pick doesn't support submodule update. Please manually cherry pick!"
         return 251
     fi
     content=$(gh pr view $PR_URL --json title,body)
@@ -111,6 +111,16 @@ labeled(){
         echo $ACTION_LABEL | grep msft- || return 0
     fi
     if echo $ACTION_LABEL | grep -E '^Approved for (msft-)?[0-9]{6} Branch$'; then
+        release_owner_key=$(echo $ACTION_LABEL | grep -Eo "[0-9]{6}")
+        release_team="release-manager-$release_owner_key"
+        if gh api "orgs/$ORG/teams/$release_team" &>/dev/null; then
+            if ! gh api "orgs/$ORG/teams/$release_team/memberships/$ACTION_SENDER" --jq '.state' 2>/dev/null | grep -q "^active$"; then
+                gh pr edit $PR_URL --remove-label "$ACTION_LABEL"
+                members=$(gh api "orgs/$ORG/teams/$release_team/members" --jq '.[].login' 2>/dev/null | sed 's/^/@/' | tr '\n' ' ')
+                gh pr comment $PR_URL --body "The label \`$ACTION_LABEL\` can only be added by a member of the @${ORG}/${release_team} team. Removing the label. Please contact one of the release managers: ${members}to approve the cherry pick."
+                return 0
+            fi
+        fi
         create_pr "$ACTION_LABEL"
         return $?
     fi

--- a/azure-pipelines/auto-cherry-pick.sh
+++ b/azure-pipelines/auto-cherry-pick.sh
@@ -40,12 +40,16 @@ check_conflict(){
     contains_submodule=""
     if [[ "$PR_MERGED" == "true" ]];then
         git reset $PR_COMMIT_SHA --hard
-        contains_submodule=$(git show HEAD | grep -Eo "^\+Subproject commit ")
+        if git show HEAD | grep -Eo "^\+Subproject commit "; then
+            contains_submodule="true"
+        fi
         git reset HEAD~
         git add . -f
     else
         git fetch head +refs/pull/$PR_NUMBER/merge:refs/remotes/pull/$PR_NUMBER/merge
-        contains_submodule=$(git log head/$PR_BASE_BRANCH..$PR_COMMIT_SHA -p | grep -Eo "^\+Subproject commit ")
+        if git log head/$PR_BASE_BRANCH..$PR_COMMIT_SHA -p | grep -Eo "^\+Subproject commit "; then
+            contains_submodule="true"
+        fi
         git merge pull/$PR_NUMBER/merge --squash || { echo "PR is Out of Date!"; return 253; }
     fi
     if [ -n "$contains_submodule" ]; then


### PR DESCRIPTION
### Description

Several refinements to the auto cherry-pick workflow (`azure-pipelines/auto-cherry-pick.sh`):

1. **Fetch branch objects before `git reset`** — `git remote update` only updates remote refs and does not guarantee the commit objects are present locally, which caused `fatal: Could not parse object` failures on `git reset $PR_COMMIT_SHA --hard`. Added an explicit `git fetch head $PR_BASE_BRANCH --depth=100`.

2. **Use the real post-merge commit for squash-merged PRs** — the webhook `PR_COMMIT_SHA` (`merge_commit_sha`) is GitHub's ephemeral test-merge object and is deleted after a squash merge. Now resolve the real `merge_commit_sha` via `gh api repos/$ORG/$REPO/pulls/$PR_NUMBER` and fetch/reset onto it.

3. **Guard against submodule changes** — detect submodule (`Subproject commit`) changes in both the merged and non-merged paths. Auto cherry-pick does not support submodule updates, so the job now comments on the PR and exits early (`return 251`) asking for a manual cherry-pick.

4. **Enforce release-manager approval for release-branch cherry-picks** — when an `Approved for <branch>` label is applied, verify the sender belongs to the `release-manager-<branch>` org team. If not, the label is removed and a comment tags the release managers. The check is skipped when the team does not exist.

5. **Fix `grep` exit code 1 issue** — prevent an empty `grep` match from failing the script under `set -e`.

### Motivation

Make the auto cherry-pick pipeline more robust (avoid transient object-fetch failures, handle squash-merge SHA deletion) and safer (block unsupported submodule updates and enforce release-manager approval on protected release branches).

### How to verify

- Re-run the auto-cherry-pick job for a PR targeting a release branch; the `git reset` step no longer fails with `Could not parse object`.
- Apply an `Approved for <branch>` label as a non–release-manager and confirm the label is removed with an explanatory comment.
- Open a PR containing a submodule bump and confirm the job comments and skips instead of cherry-picking.