### PR TITLE
[agent provisioning] remove python3-pip from apt install list

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -80,7 +80,7 @@ usermod -a -G docker azureuser || true
 cat /etc/passwd /etc/group || true
 
 # Install build tools (and waiting docker ready)
-apt-get install -y build-essential nfs-common python3-pip python3-setuptools python3-pip python-is-python3
+apt-get install -y build-essential nfs-common python3-setuptools python-is-python3
 
 # Install uv (system-wide) and use it to install Python packages without pip
 curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh


### PR DESCRIPTION
Follow-up to #181: now that `uv` installs the Python build dependencies, `python3-pip` is no longer needed here. It also triggers S360 security alerts, so drop it from the apt install list.
