### PR TITLE
[ci] scan PR description to add 'Tested for xxx branch' label

### DIFF
--- a/azure-pipelines/pr-body-scan.yml
+++ b/azure-pipelines/pr-body-scan.yml
@@ -6,7 +6,7 @@ trigger: none
 pr: none
 
 schedules:
-- cron: "11 11 * * *"
+- cron: "11 */6 * * *"
   branches:
     include:
     - main
@@ -110,24 +110,99 @@ jobs:
                 if echo "$request_labels_created_by_bot" | grep -qiFx "$label"; then
                   labels_to_remove="${labels_to_remove:+$labels_to_remove,}$label"
                   branches_to_remove="${branches_to_remove:+$branches_to_remove,}$branch"
+                  tested_label="Tested for $branch Branch"
+                  if echo "$labels" | grep -qiF "$tested_label"; then
+                    labels_to_remove="${labels_to_remove:+$labels_to_remove,}$tested_label"
+                  fi
                 fi
               fi
             done
             if [[ -n "$labels_to_remove" ]]; then
               if gh pr edit "$url" --remove-label "$labels_to_remove"; then
+                while IFS= read -r removed_label; do
+                  [[ -z "$removed_label" ]] && continue
+                  labels=$(echo "$labels" | grep -vFx "$removed_label" || true)
+                done <<< "$(echo "$labels_to_remove" | tr ',' '\n')"
                 comment_pr "$url" "The backport request for branch(es) $branches_to_remove has been removed from PR description. Removed label(s)...."
                 echo "Removed labels for branch(es) $labels_to_remove for $url" >> cherry_pick_scan.log
               else
                 echo "Failed to remove label(s) for branch(es) $branches_to_remove for $url" >> cherry_pick_scan.log
               fi
             fi
+            # Check Tested branch and Test result sections for PRs with backport request labels
+            current_request_labels=$(echo "$labels" | grep -P 'Request for (?:msft-)?\d{6} Branch' || true)
+            if [[ -n "$current_request_labels" ]]; then
+              tested_section=$(echo "$body_no_comments" | awk 'tolower($0) ~ /^#{3,}.*tested branch/{found=1; next} found && /^#{3,}/{exit} found{print}')
+              tested_branches_checked=$(echo "$tested_section" | grep -oiP '^\s*-\s*\[[xX]\]\s*\K\S+' | grep -viF 'N/A' || true)
+              test_result_section=$(echo "$body_no_comments" | awk 'tolower($0) ~ /^#{3,}.*test result/{found=1; next} found && /^#{3,}/{exit} found{print}')
+              test_result_content=$(echo "$test_result_section" | sed '/^\s*$/d' || true)
+              labels_to_add_tested=""
+              labels_to_remove_tested=""
+              missing_tested_for=""
+              while IFS= read -r req_label; do
+                [[ -z "$req_label" ]] && continue
+                branch=$(echo "$req_label" | grep -oP '(?<=Request for )(?:msft-)?\d{6}(?= Branch)')
+                raw_branch=${branch#msft-}
+                tested_label="Tested for $branch Branch"
+                if echo "$labels" | grep -qiF "$tested_label"; then
+                  if ! (echo "$tested_branches_checked" | grep -qiF "$raw_branch" && echo "$test_result_content" | grep -qF "$raw_branch"); then
+                    labels_to_remove_tested="${labels_to_remove_tested:+$labels_to_remove_tested,}$tested_label"
+                  fi
+                  continue
+                fi
+                if echo "$tested_branches_checked" | grep -qiF "$raw_branch" && echo "$test_result_content" | grep -qF "$raw_branch"; then
+                  labels_to_add_tested="${labels_to_add_tested:+$labels_to_add_tested,}$tested_label"
+                else
+                  missing_tested_for="${missing_tested_for:+$missing_tested_for,}$branch"
+                fi
+              done <<< "$current_request_labels"
+              if [[ -n "$labels_to_add_tested" ]]; then
+                if gh pr edit "$url" --add-label "$labels_to_add_tested"; then
+                  labels_added=$(echo "$labels_to_add_tested" | tr ',' '\n')
+                  labels=$(printf "%s\n%s\n" "$labels" "$labels_added" | sed '/^$/d' | sort -fu)
+                  tested_branches_list=$(echo "$labels_to_add_tested" | grep -oP '(?<=Tested for )(?:msft-)?\d{6}(?= Branch)' | paste -sd ',' -)
+                  comment_pr "$url" "The **Tested branch** section has been ticked and **Test result** is provided for branch(es): $tested_branches_list. Added label(s): $labels_to_add_tested."
+                  echo "Added tested label(s) for $url: $labels_to_add_tested" >> cherry_pick_scan.log
+                else
+                  comment_pr "$url" "@yijingyan2 @lunyue-ms Failed to add tested label(s): $labels_to_add_tested. The label(s) may not exist. Please check manually."
+                  echo "Failed to add tested label(s) for $url: $labels_to_add_tested" >> cherry_pick_scan.log
+                fi
+              fi
+              if [[ -n "$labels_to_remove_tested" ]]; then
+                if gh pr edit "$url" --remove-label "$labels_to_remove_tested"; then
+                  removed_tested_branches=$(echo "$labels_to_remove_tested" | grep -oP '(?<=Tested for )(?:msft-)?\d{6}(?= Branch)' | paste -sd ',' -)
+                  comment_pr "$url" "The **Tested branch** tick or **Test result** has been removed for branch(es): $removed_tested_branches. Removed label(s): $labels_to_remove_tested."
+                  echo "Removed tested label(s) for $url: $labels_to_remove_tested" >> cherry_pick_scan.log
+                else
+                  echo "Failed to remove tested label(s) for $url: $labels_to_remove_tested" >> cherry_pick_scan.log
+                fi
+              fi
+              if [[ -n "$missing_tested_for" ]]; then
+                existing_missing_comment_bodies=$(gh api "repos/$repo/issues/$pr_number/comments" --jq '[.[] | select(.user.login == "mssonicbld" and (.body | test("missing required test information"; "i"))) | .body] | join("\n")' 2>/dev/null || echo "")
+                uncovered_branches=""
+                while IFS= read -r mb; do
+                  [[ -z "$mb" ]] && continue
+                  raw_mb=${mb#msft-}
+                  if ! echo "$existing_missing_comment_bodies" | grep -qF "$raw_mb"; then
+                    uncovered_branches="${uncovered_branches:+$uncovered_branches,}$mb"
+                  fi
+                done <<< "$(echo "$missing_tested_for" | tr ',' '\n')"
+                if [[ -n "$uncovered_branches" ]]; then
+                  first_branch=$(echo "$uncovered_branches" | cut -d',' -f1)
+                  raw_first_branch=${first_branch#msft-}
+                  missing_msg="This PR has backport request label(s) for branch(es): $uncovered_branches, but is missing required test information. Please make sure you tick the tested branch(es) in the **Tested branch** section and provide test evidence (e.g., $raw_first_branch: &lt;test result&gt;) in the **Test result** section as well in your PR description."
+                  comment_pr "$url" "$missing_msg"
+                  echo "Left comment about missing test info for $url" >> cherry_pick_scan.log
+                fi
+              fi
+            fi
           done
         done
-      displayName: cherry pick scanning
+      displayName: PR description scanning
     - script: |
         set -ex
         [ -f cherry_pick_scan.log ] && cat cherry_pick_scan.log
-      displayName: show cherry pick scanning result
+      displayName: show PR description scanning result
       condition: always()
     - script: |
         set -ex

--- a/azure-pipelines/pr-body-scan.yml
+++ b/azure-pipelines/pr-body-scan.yml
@@ -99,7 +99,9 @@ jobs:
               fi
             fi
             pr_number=$(echo "$url" | grep -Eo '[0-9]+$')
-            request_labels_created_by_bot=$(gh api "repos/$repo/issues/$pr_number/events?per_page=100" --paginate | jq -r '.[] | select(.event == "labeled" and (.actor.login // "") == "mssonicbld" and (.label.name // "" | test("^Request for (msft-)?[0-9]{6} Branch$"))) | .label.name' | sort -u)
+            bot_created_labels=$(gh api "repos/$repo/issues/$pr_number/events?per_page=100" --paginate | jq -r '.[] | select(.event == "labeled" and (.actor.login // "") == "mssonicbld" and (.label.name // "" | test("^(Request|Tested) for (msft-)?[0-9]{6} Branch$"))) | .label.name' | sort -u)
+            request_labels_created_by_bot=$(echo "$bot_created_labels" | grep -P '^Request for ' || true)
+            tested_labels_created_by_bot=$(echo "$bot_created_labels" | grep -P '^Tested for ' || true)
             branches_with_request_label=$(echo "$labels" | grep -oP '(?<=Request for )(?:msft-)?\d{6}(?= Branch)' || true)
             labels_to_remove=""
             branches_to_remove=""
@@ -112,7 +114,9 @@ jobs:
                   branches_to_remove="${branches_to_remove:+$branches_to_remove,}$branch"
                   tested_label="Tested for $branch Branch"
                   if echo "$labels" | grep -qiF "$tested_label"; then
-                    labels_to_remove="${labels_to_remove:+$labels_to_remove,}$tested_label"
+                    if echo "$tested_labels_created_by_bot" | grep -qiFx "$tested_label"; then
+                      labels_to_remove="${labels_to_remove:+$labels_to_remove,}$tested_label"
+                    fi
                   fi
                 fi
               fi
@@ -146,7 +150,9 @@ jobs:
                 tested_label="Tested for $branch Branch"
                 if echo "$labels" | grep -qiF "$tested_label"; then
                   if ! (echo "$tested_branches_checked" | grep -qiF "$raw_branch" && echo "$test_result_content" | grep -qF "$raw_branch"); then
-                    labels_to_remove_tested="${labels_to_remove_tested:+$labels_to_remove_tested,}$tested_label"
+                    if echo "$tested_labels_created_by_bot" | grep -qiFx "$tested_label"; then
+                      labels_to_remove_tested="${labels_to_remove_tested:+$labels_to_remove_tested,}$tested_label"
+                    fi
                   fi
                   continue
                 fi
@@ -164,7 +170,10 @@ jobs:
                   comment_pr "$url" "The **Tested branch** section has been ticked and **Test result** is provided for branch(es): $tested_branches_list. Added label(s): $labels_to_add_tested."
                   echo "Added tested label(s) for $url: $labels_to_add_tested" >> cherry_pick_scan.log
                 else
-                  comment_pr "$url" "@yijingyan2 @lunyue-ms Failed to add tested label(s): $labels_to_add_tested. The label(s) may not exist. Please check manually."
+                  existing_failure_comments=$(gh api "repos/$repo/issues/$pr_number/comments" --jq '[.[] | select(.user.login == "mssonicbld" and (.body | test("Failed to add tested label"; "i")))] | length' 2>/dev/null || echo "0")
+                  if [[ "$existing_failure_comments" == "0" ]]; then
+                    comment_pr "$url" "@yijingyan2 @lunyue-ms Failed to add tested label(s): $labels_to_add_tested. The label(s) may not exist. Please check manually."
+                  fi
                   echo "Failed to add tested label(s) for $url: $labels_to_add_tested" >> cherry_pick_scan.log
                 fi
               fi


### PR DESCRIPTION
Enhance PR body scanning: add Tested branch/Test result tracking

**changes:**
- Run every 6 hours instead of once daily
- New: scan Tested branch and Test result sections for PRs that have a Request for xxx Branch label. If the corresponding branch checkbox is ticked in `Tested branch` section and `Test result` is non-empty → add Tested for xxx Branch label and leave a comment explaining why. If either is missing → leave a comment asking the contributor to tick the tested branch(es) and provide test evidence

**motivation**
verifying that the contributor has tested the change on the requested branch(es) before release owner adds 'Approved for xxx Branch' label.