### PR TITLE
[ci] add a pipeline to trigger submodule pipelines on commits pointed by sonic-buildimage

### DIFF
--- a/azure-pipelines/submodule-pipelines-trigger.md
+++ b/azure-pipelines/submodule-pipelines-trigger.md
@@ -1,0 +1,118 @@
+# Submodule Pipelines Trigger
+
+`submodule-pipelines-trigger.yml` validates the SONiC submodule build pipelines in
+**dependency-level order** against the exact submodule commits pinned by
+[`sonic-buildimage`](https://github.com/sonic-net/sonic-buildimage), and — if every level
+passes — opens a "validated" pull request back to `sonic-buildimage`.
+
+It is a manual / scheduled pipeline (`trigger: none`, `pr: none`); it is not triggered by
+commits.
+
+## What it does
+
+1. **Resolve the buildimage commit.** Finds the latest *successful* run of the
+   `sonic-buildimage` official build pipeline (`VSbBuildPipelineId`, default `142`) on
+   `master` and reads the commit (`sourceVersion`) it built.
+2. **Trigger submodules, level by level.** For each dependency level, in order, it resolves
+   every submodule's pinned SHA at that buildimage commit and queues the matching build
+   pipeline. A level must fully succeed before the next level starts.
+3. **Retry on failure.** If a triggered run fails, it retries the *failed stages in the same
+   run* (via the Azure DevOps REST timeline + stage `retry` API) once before giving up.
+4. **Open a validation PR.** After all levels pass, the `CreatePR` stage collects the
+   validated commits, writes them to a tracking file, and opens a PR to
+   `sonic-net/sonic-buildimage` (from the `mssonicbld` fork) with the **`automerge`** label.
+
+## Stage flow
+
+```
+ResolveCommit
+   └─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
+```
+
+Each `levelN` stage depends on `ResolveCommit` (to read the buildimage SHA output) **and**
+on the previous level (to enforce ordering). `CreatePR` depends on `ResolveCommit` and all
+levels, and runs only on `succeeded()`.
+
+## Dependency levels
+
+Levels encode build order — a submodule is placed in a level after everything it depends on.
+Within a level, all submodule pipelines run **in parallel** (one job each).
+
+| Level | Submodules (path → pipeline id) |
+|-------|----------------------------------|
+| level0 | `common_libs` (465), `src/sonic-dash-api` (1318) |
+| level1 | `platform/vpp` (1016), `src/sonic-swss-common` (9), `src/sonic-platform-common` (42), `src/sonic-platform-daemons` (41), `src/sonic-host-services` (935), `src/sonic-mgmt-framework` (130), `src/sonic-mgmt-common` (127), `src/sonic-snmpagent` (106), `src/sonic-dbsyncd` (110) |
+| level2 | `src/sonic-sairedis` (12), `src/sonic-gnmi` (934), `src/sonic-utilities` (55), `src/sonic-bmp` (1565), `src/sonic-dash-ha` (2351), `src/linkmgrd` (388), `src/dhcpmon` (901), `src/dhcprelay` (487), `src/sonic-stp` (84), `src/wpasupplicant/sonic-wpa-supplicant` (5) |
+| level3 | `src/sonic-swss` (15) |
+
+> `common_libs` is special-cased: it is not a submodule gitlink, so its commit is the
+> buildimage commit itself (`git rev-parse HEAD`). All other entries resolve their pinned
+> commit via `git ls-tree <buildimageSha> <path>`.
+
+## Parameters
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `targetProject` | string | `build` | Azure DevOps project that hosts the submodule pipelines. |
+| `VSbBuildPipelineId` | string | `142` | Pipeline id of the `sonic-buildimage` official build, used to resolve the reference commit. |
+| `levels` | object | see above | Ordered list of levels; each has `name`, `dependsOn` (list), and a `pipelines` map of `submodule-path: pipeline-id`. |
+
+## How a submodule job works
+
+For each `submodule-path: pipeline-id` in a level:
+
+1. Clone `sonic-buildimage`, check out the resolved buildimage SHA, and read the submodule's
+   pinned commit. A missing pinned commit is treated as a **configuration error** and fails
+   the job (wrong path or a removed/renamed submodule).
+2. Queue the submodule pipeline at that commit
+   (`az pipelines run --id <pipeline-id> --commit-id <sha> --branch refs/heads/master`).
+3. Poll run status every 600s until `completed`; treat `succeeded` **or**
+   `partiallySucceeded` as pass.
+4. On failure, retry the failed stages in the same run once, then wait for the retried
+   attempt to finish.
+5. Publish the validated `path=sha` record as a pipeline artifact
+   (`commits_<level>_<safe-path>`) for the `CreatePR` stage.
+
+Each job has `timeoutInMinutes: 540` (9h) — this is the ceiling for a single submodule
+build plus queue/poll time.
+
+## Requirements
+
+The pipeline expects the following to already exist in the Azure DevOps org / target project:
+
+- **Service connection** `mssonic-automation-umi` (a User-Assigned Managed Identity) used by
+  every `AzureCLI@2` task. It authenticates to Azure DevOps via an AAD access token for the
+  Azure DevOps resource (`499b84ac-1321-427f-aa17-267ca6975798`).
+- **Variable group** `sonicbld` containing `GITHUB-TOKEN` — a GitHub token for the
+  `mssonicbld` bot with push access to the `mssonicbld/sonic-buildimage` fork and permission
+  to open PRs against `sonic-net/sonic-buildimage`.
+- The **`mssonicbld/sonic-buildimage`** fork (PR head branch is pushed there).
+- The **`automerge`** label must exist in `sonic-net/sonic-buildimage`.
+- Agent pool **`sonic-ubuntu-1c`** with enough parallelism to cover the widest level
+  (level1/level2 each fan out to ~10 concurrent jobs, and each job holds an agent for the
+  duration of the downstream build).
+
+## Running it
+
+Trigger the pipeline manually (or on a schedule) from Azure DevOps. To override a default,
+supply the parameter at queue time — e.g. point at a different reference build with
+`VSbBuildPipelineId`, or target a different project with `targetProject`.
+
+## Adding or reordering a submodule
+
+Edit the `levels` parameter default:
+
+- Add the `submodule-path: pipeline-id` entry to the level whose dependencies it satisfies.
+- If it depends on something in a later level, move it (or that dependency) so the ordering
+  holds — everything a submodule needs must be in an earlier level.
+- The `submodule-path` must match the path as pinned in `sonic-buildimage`
+  (what `git ls-tree` reports); a wrong path fails the job by design.
+
+## The validation PR
+
+`CreatePR` assembles all published `path=sha` records, commits them to a
+`validated-submodule-commits` tracking file on branch `validated-submodules` in the
+`mssonicbld` fork, and opens (or updates) a PR titled
+`[validated] Submodule pipeline runs passed for <buildimageSha>` with the `automerge` label.
+If a PR for the branch already exists, the branch is force-pushed and the existing PR is
+re-labeled instead of failing.

--- a/azure-pipelines/submodule-pipelines-trigger.yml
+++ b/azure-pipelines/submodule-pipelines-trigger.yml
@@ -1,0 +1,334 @@
+# Trigger submodule pipelines in dependency-level order against the commit pinned by
+# sonic-buildimage. Level 0 runs first; only after every Level-0 pipeline succeeds does
+# Level 1 start, then Level 2, and so on.
+#
+# Finds the latest successful run of the sonic-buildimage official pipeline, reads the
+# commit it built, then for each level resolves every submodule SHA pinned at that commit
+# and queues the matching pipeline, waiting for the whole level to finish before the next.
+
+trigger: none
+pr: none
+
+parameters:
+- name: targetProject
+  type: string
+  default: build
+- name: VSbBuildPipelineId
+  type: string
+  default: '142'
+- name: levels
+  type: object
+  default:
+  - name: level0
+    dependsOn: [ResolveCommit]
+    pipelines:
+      common_libs: '465'
+      src/sonic-dash-api: '1318'
+  - name: level1
+    dependsOn: [ResolveCommit, level0]
+    pipelines:
+      platform/vpp: '1016'
+      src/sonic-swss-common: '9'
+      src/sonic-platform-common: '42'
+      src/sonic-platform-daemons: '41'
+      src/sonic-host-services: '935'
+      src/sonic-mgmt-framework: '130'
+      src/sonic-mgmt-common: '127'
+      src/sonic-snmpagent: '106'
+      src/sonic-dbsyncd: '110'
+  - name: level2
+    dependsOn: [ResolveCommit, level1]
+    pipelines:
+      src/sonic-sairedis: '12'
+      src/sonic-gnmi: '934'
+      src/sonic-utilities: '55'
+      src/sonic-bmp: '1565'
+      src/sonic-dash-ha: '2351'
+      src/linkmgrd: '388'
+      src/dhcpmon: '901'
+      src/dhcprelay: '487'
+      src/sonic-stp: '84'
+      src/wpasupplicant/sonic-wpa-supplicant: '5'
+  - name: level3
+    dependsOn: [ResolveCommit, level2]
+    pipelines:
+      src/sonic-swss: '15'
+
+stages:
+- stage: ResolveCommit
+  jobs:
+  - job: Resolve
+    pool: sonic-ubuntu-1c
+    steps:
+    - checkout: none
+    - bash: |
+        set -e
+        command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
+    - task: AzureCLI@2
+      name: resolve
+      displayName: 'Resolve sonic-buildimage commit'
+      inputs:
+        azureSubscription: 'mssonic-automation-umi'
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -e
+          az extension add --name azure-devops --yes
+          AZURE_DEVOPS_EXT_PAT=$(az account get-access-token \
+            --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+          export AZURE_DEVOPS_EXT_PAT
+          SHA=$(az pipelines runs list \
+            --pipeline-ids ${{ parameters.VSbBuildPipelineId }} \
+            --project ${{ parameters.targetProject }} \
+            --organization "$(System.CollectionUri)" \
+            --branch refs/heads/master \
+            --result succeeded \
+            --status completed \
+            --top 1 \
+            --query-order FinishTimeDesc \
+            --query "[0].sourceVersion" -o tsv)
+          if [ -z "$SHA" ]; then
+            echo "No successful run found for pipeline ${{ parameters.VSbBuildPipelineId }}"
+            exit 1
+          fi
+          echo "sonic-buildimage commit from latest successful run: $SHA"
+          echo "##vso[task.setvariable variable=buildimageSha;isOutput=true]$SHA"
+- ${{ each level in parameters.levels }}:
+  - stage: ${{ level.name }}
+    dependsOn: ${{ level.dependsOn }}
+    variables:
+      buildimageSha: $[ stageDependencies.ResolveCommit.Resolve.outputs['resolve.buildimageSha'] ]
+    jobs:
+    - ${{ each pipeline in level.pipelines }}:
+      - job:
+        pool: sonic-ubuntu-1c
+        displayName: '${{ pipeline.key }}'
+        timeoutInMinutes: 540
+        steps:
+        - checkout: none
+        - bash: |
+            set -e
+            command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          displayName: 'Install Azure CLI'
+        - task: AzureCLI@2
+          displayName: 'Trigger ${{ pipeline.key }} pipeline'
+          inputs:
+            azureSubscription: 'mssonic-automation-umi'
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              set -e
+              az extension add --name azure-devops --yes
+              export AZURE_DEVOPS_EXT_PAT=$(az account get-access-token \
+                --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+              git clone https://github.com/sonic-net/sonic-buildimage buildimage
+              cd buildimage
+              git checkout $(buildimageSha)
+              mkdir -p "$(Pipeline.Workspace)/commits"
+              if [ "${{ pipeline.key }}" = "common_libs" ]; then
+                SHA=$(git rev-parse HEAD)
+              else
+                SHA=$(git ls-tree HEAD '${{ pipeline.key }}' | awk '{print $3}')
+              fi
+              if [ -z "$SHA" ]; then
+                echo "No pinned commit found for ${{ pipeline.key }} at $(buildimageSha); the path is likely wrong or the submodule was removed"
+                exit 1
+              fi
+              echo "Pinned commit for ${{ pipeline.key }}: $SHA"
+              run_pipeline() {
+                RUN_ID=$(az pipelines run \
+                  --id ${{ pipeline.value }} \
+                  --project ${{ parameters.targetProject }} \
+                  --commit-id $SHA \
+                  --branch refs/heads/master \
+                  --organization "$(System.CollectionUri)" \
+                  --query id -o tsv)
+                if [ -z "$RUN_ID" ]; then
+                  echo "Failed to queue ${{ pipeline.key }} (pipeline ${{ pipeline.value }}) at $SHA"
+                  return 1
+                fi
+                URL="$(System.CollectionUri)${{ parameters.targetProject }}/_build/results?buildId=$RUN_ID&view=results"
+                echo "Queued run $RUN_ID for ${{ pipeline.key }}: $URL"
+                while true; do
+                  ST=$(az pipelines runs show --id $RUN_ID --project ${{ parameters.targetProject }} \
+                    --organization "$(System.CollectionUri)" --query status -o tsv)
+                  if [ "$ST" = "completed" ]; then break; fi
+                  sleep 600
+                done
+                RESULT=$(az pipelines runs show --id $RUN_ID --project ${{ parameters.targetProject }} \
+                  --organization "$(System.CollectionUri)" --query result -o tsv)
+                echo "${{ pipeline.key }} run $RUN_ID result: $RESULT"
+                [ "$RESULT" = "succeeded" ] || [ "$RESULT" = "partiallySucceeded" ]
+              }
+              get_run_field() {
+                az pipelines runs show --id $1 --project ${{ parameters.targetProject }} \
+                  --organization "$(System.CollectionUri)" --query "$2" -o tsv
+              }
+              retry_failed_stages() {
+                local RUN_ID=$1
+                local TIMELINE
+                TIMELINE=$(curl -sS \
+                  -H "Authorization: Bearer $AZURE_DEVOPS_EXT_PAT" \
+                  "$(System.CollectionUri)${{ parameters.targetProject }}/_apis/build/builds/${RUN_ID}/timeline?api-version=7.1")
+                local STAGES
+                STAGES=$(echo "$TIMELINE" | python3 -c 'import sys, json; d = json.load(sys.stdin); print("\n".join(r["identifier"] for r in d.get("records", []) if r.get("type") == "Stage" and r.get("result") == "failed"))')
+                if [ -z "$STAGES" ]; then
+                  echo "No failed stages found to retry for ${{ pipeline.key }}"
+                  return 1
+                fi
+                for STAGE in $STAGES; do
+                  echo "Retrying failed stage '$STAGE' in run $RUN_ID"
+                  curl -sS -X PATCH \
+                    -H "Authorization: Bearer $AZURE_DEVOPS_EXT_PAT" \
+                    -H "Content-Type: application/json" \
+                    -d '{"state": "retry"}' \
+                    "$(System.CollectionUri)${{ parameters.targetProject }}/_apis/build/builds/${RUN_ID}/stages/${STAGE}?api-version=7.1-preview.1"
+                done
+                return 0
+              }
+              wait_for_run() {
+                local RUN_ID=$1
+                local PREV_FINISH=$2
+                # Wait for the run to leave its previous completed state, i.e. the retried attempt has started.
+                local WAITED=0
+                while true; do
+                  ST=$(get_run_field $RUN_ID status)
+                  FIN=$(get_run_field $RUN_ID finishTime)
+                  if [ "$ST" != "completed" ] || [ "$FIN" != "$PREV_FINISH" ]; then break; fi
+                  if [ $WAITED -ge 600 ]; then
+                    echo "${{ pipeline.key }} run $RUN_ID did not restart after retry request"
+                    return 1
+                  fi
+                  sleep 30
+                  WAITED=$((WAITED + 30))
+                done
+                # Wait for the retried attempt to complete.
+                while true; do
+                  ST=$(get_run_field $RUN_ID status)
+                  if [ "$ST" = "completed" ]; then break; fi
+                  sleep 600
+                done
+                RESULT=$(get_run_field $RUN_ID result)
+                echo "${{ pipeline.key }} retry run $RUN_ID result: $RESULT"
+                [ "$RESULT" = "succeeded" ] || [ "$RESULT" = "partiallySucceeded" ]
+              }
+              if ! run_pipeline; then
+                if [ -z "$RUN_ID" ]; then
+                  echo "${{ pipeline.key }} could not be queued (no run id), nothing to retry, exiting"
+                  exit 1
+                fi
+                echo "First attempt failed for ${{ pipeline.key }}, retrying failed stages in the same run"
+                PREV_FINISH=$(get_run_field $RUN_ID finishTime)
+                if ! retry_failed_stages $RUN_ID; then
+                  echo "Could not trigger stage retry for ${{ pipeline.key }}, exiting"
+                  exit 1
+                fi
+                echo "Waiting for retried stages to complete"
+                if ! wait_for_run $RUN_ID "$PREV_FINISH"; then
+                  echo "Retry failed for ${{ pipeline.key }}, exiting"
+                  exit 1
+                fi
+              fi
+              # Publish the validated commit as a pipeline artifact for the CreatePR stage
+              SAFE_KEY=$(echo '${{ pipeline.key }}' | tr '/' '_')
+              echo "${{ pipeline.key }}=$SHA" > "$(Pipeline.Workspace)/commits/${SAFE_KEY}"
+        - publish: $(Pipeline.Workspace)/commits
+          artifact: commits_${{ level.name }}_${{ replace(pipeline.key, '/', '_') }}
+          displayName: 'Publish commit record'
+  
+- stage: CreatePR
+  dependsOn:
+  - ResolveCommit
+  - ${{ each level in parameters.levels }}:
+    - ${{ level.name }}
+  condition: succeeded()
+  variables:
+  - group: sonicbld
+  jobs:
+  - job: CreatePR
+    pool: sonic-ubuntu-1c
+    variables:
+      buildimageSha: $[ stageDependencies.ResolveCommit.Resolve.outputs['resolve.buildimageSha'] ]
+    steps:
+    - checkout: none
+    - download: current
+      patterns: '**'
+      displayName: 'Download commit artifacts'
+    - bash: |
+        set -e
+        command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        command -v gh >/dev/null || { curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list && sudo apt update && sudo apt install gh -y; }
+      displayName: 'Install Azure CLI and gh'
+    - task: AzureCLI@2
+      displayName: 'Create sonic-buildimage PR with validated submodule commits'
+      inputs:
+        azureSubscription: 'mssonic-automation-umi'
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -e
+          az extension add --name azure-devops --yes
+          AZURE_DEVOPS_EXT_PAT=$(az account get-access-token \
+            --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+          export AZURE_DEVOPS_EXT_PAT
+          set -x
+          # Assemble commit record from artifacts published by each trigger job
+          RECORD=""
+          for f in $(Pipeline.Workspace)/commits_*/*; do
+            line=$(cat "$f")
+            RECORD+="${line}"$'\n'
+          done
+
+          echo "--- Validated submodule commits ---"
+          echo "$RECORD"
+
+          # Clone latest master to base the PR on
+          git clone --depth=1 https://github.com/sonic-net/sonic-buildimage buildimage
+          cd buildimage
+          git config user.email "sonicbld@microsoft.com"
+          git config user.name "Sonic Build Admin"
+          git remote add mssonicbld "https://mssonicbld:${GH_TOKEN}@github.com/mssonicbld/sonic-buildimage"
+
+          MASTER_SHA=$(git rev-parse --short HEAD)
+          BRANCH="validated-submodules"
+          git checkout -b "$BRANCH"
+
+          # Write validated commits to a tracking file (fixed path so each run overwrites it)
+          TRACKING_FILE="validated-submodule-commits"
+
+          printf "buildimage=%s\n%s" "$BUILDIMAGE_SHA" "$RECORD" > "$TRACKING_FILE"
+
+          git add "$TRACKING_FILE"
+          BODY="Validated submodule pipeline runs for buildimage commit \`$BUILDIMAGE_SHA\` on master \`$MASTER_SHA\`:"$'\n\n'
+          BODY+='```'$'\n'
+          BODY+="$RECORD"
+          BODY+=$'\n''```'
+
+          git diff --cached --quiet && echo "No submodule changes to commit" && exit 0
+
+          git commit -s \
+            -m "[validated] Submodule pipeline runs passed for $BUILDIMAGE_SHA" \
+            -m "$BODY"
+          git push mssonicbld HEAD:"$BRANCH" -f
+
+          if ! gh pr create \
+            -R sonic-net/sonic-buildimage \
+            -H "mssonicbld:$BRANCH" \
+            -B master \
+            -t "[validated] Submodule pipeline runs passed for $BUILDIMAGE_SHA" \
+            -b "$BODY" \
+            --label automerge; then
+            EXISTING=$(gh pr list -R sonic-net/sonic-buildimage \
+              -H "mssonicbld:$BRANCH" --state open --json number -q '.[0].number' || true)
+            if [ -n "$EXISTING" ]; then
+              echo "PR already exists for mssonicbld:$BRANCH: #$EXISTING (force-pushed branch is updated)"
+              gh pr edit "$EXISTING" -R sonic-net/sonic-buildimage --add-label automerge || true
+            else
+              echo "Failed to create PR for mssonicbld:$BRANCH"
+              exit 1
+            fi
+          fi
+      env:
+        GH_TOKEN: $(GITHUB-TOKEN)
+        BUILDIMAGE_SHA: $(buildimageSha)

--- a/azure-pipelines/submodule-pipelines-trigger.yml
+++ b/azure-pipelines/submodule-pipelines-trigger.yml
@@ -101,7 +101,7 @@ stages:
       buildimageSha: $[ stageDependencies.ResolveCommit.Resolve.outputs['resolve.buildimageSha'] ]
     jobs:
     - ${{ each pipeline in level.pipelines }}:
-      - job:
+      - job: trigger_${{ replace(replace(pipeline.key, '/', '_'), '-', '_') }}
         pool: sonic-ubuntu-1c
         displayName: '${{ pipeline.key }}'
         timeoutInMinutes: 540


### PR DESCRIPTION
## What

Adds `azure-pipelines/submodule-pipelines-trigger.yml` (plus a `submodule-pipelines-trigger.md` README) — a manual/scheduled pipeline that validates the SONiC submodule build pipelines against the exact submodule commits pinned by `sonic-buildimage`, in dependency-level order, and opens a "validated" PR back to `sonic-buildimage` when everything passes.

## Why

Submodule build pipelines depend on each other's artifacts (a later-level pipeline downloads build artifacts produced by earlier levels). This pipeline exercises them in the correct order against a known-good buildimage commit, so we can validate a coherent set of submodule commits together before proposing them to `sonic-buildimage`.

## How it works

1. **ResolveCommit** — finds the latest successful run of the `sonic-buildimage` official build (`VSbBuildPipelineId`, default `142`) on `master` and reads the commit it built.
2. **level0 -> level1 -> level2 -> level3** — each level resolves every submodule's pinned SHA at that buildimage commit and queues the matching build pipeline. A level must fully succeed before the next starts (later levels consume earlier levels' artifacts). Within a level, pipelines run in parallel.
   - `common_libs` is special-cased (uses the buildimage commit itself, not a submodule gitlink).
   - A triggered run is polled to completion; `succeeded`/`partiallySucceeded` count as pass.
   - On failure, the failed stages are retried once in the same run via the Azure DevOps REST timeline + stage-retry API.
   - Each validated `path=sha` is published as a pipeline artifact.
3. **CreatePR** — collects the validated commits, writes them to a tracking file, and opens (or updates) a PR to `sonic-net/sonic-buildimage` from the `mssonicbld` fork with the `automerge` label.

