### PR TITLE
Fix duplicate bot comments in pr-body-scan (paginate comment dedup)

### DIFF
--- a/azure-pipelines/pr-body-scan.yml
+++ b/azure-pipelines/pr-body-scan.yml
@@ -134,7 +134,7 @@ jobs:
               fi
             fi
             # Check Tested branch and Test result sections for PRs with backport request labels
-            current_request_labels=$(echo "$labels" | grep -P 'Request for (?:msft-)?\d{6} Branch' || true)
+            current_request_labels=$(echo "$labels" | grep -iP 'Request for (?:msft-)?\d{6} Branch' || true)
             if [[ -n "$current_request_labels" ]]; then
               tested_section=$(echo "$body_no_comments" | awk 'tolower($0) ~ /^#{3,}.*tested branch/{found=1; next} found && /^#{3,}/{exit} found{print}')
               tested_branches_checked=$(echo "$tested_section" | grep -oiP '^\s*-\s*\[[xX]\]\s*\K\S+' | grep -viF 'N/A' || true)

--- a/azure-pipelines/pr-body-scan.yml
+++ b/azure-pipelines/pr-body-scan.yml
@@ -63,7 +63,7 @@ jobs:
             body_no_comments=$(echo "$body" | awk 'BEGIN{in_comment=0} /<!--/{in_comment=1} !in_comment{print} /-->/{in_comment=0}')
             labels=$(echo $pr | jq .labels[].name -r)
             backport_section=$(echo "$body_no_comments" | awk 'tolower($0) ~ /^#{3,}.*?(backport|back port)/{found=1; next} found && /^#{3,}/{exit} found{print}')
-            backport_branches=$(echo "$backport_section" | grep -oP '^\s*(?:-\s*\[[xX]\]\s*)?\K\d{6}(?=\s*$)' || true)
+            backport_branches=$(echo "$backport_section" | grep -oiP '^\s*(?:-\s*\[[xX]\]\s*)?\K\d{6}(?=\s*$)' || true)
             echo "Found backport branches: $backport_branches"
             labels_to_add=""
             branches_to_add=""
@@ -102,7 +102,7 @@ jobs:
             bot_created_labels=$(gh api "repos/$repo/issues/$pr_number/events?per_page=100" --paginate | jq -r '.[] | select(.event == "labeled" and (.actor.login // "") == "mssonicbld" and (.label.name // "" | test("^(Request|Tested) for (msft-)?[0-9]{6} Branch$"))) | .label.name' | sort -u)
             request_labels_created_by_bot=$(echo "$bot_created_labels" | grep -P '^Request for ' || true)
             tested_labels_created_by_bot=$(echo "$bot_created_labels" | grep -P '^Tested for ' || true)
-            branches_with_request_label=$(echo "$labels" | grep -oP '(?<=Request for )(?:msft-)?\d{6}(?= Branch)' || true)
+            branches_with_request_label=$(echo "$labels" | grep -oiP '(?<=Request for )(?:msft-)?\d{6}(?= Branch)' || true)
             labels_to_remove=""
             branches_to_remove=""
             for branch in $branches_with_request_label; do
@@ -145,7 +145,7 @@ jobs:
               missing_tested_for=""
               while IFS= read -r req_label; do
                 [[ -z "$req_label" ]] && continue
-                branch=$(echo "$req_label" | grep -oP '(?<=Request for )(?:msft-)?\d{6}(?= Branch)')
+                branch=$(echo "$req_label" | grep -oiP '(?<=Request for )(?:msft-)?\d{6}(?= Branch)')
                 raw_branch=${branch#msft-}
                 tested_label="Tested for $branch Branch"
                 if echo "$labels" | grep -qiF "$tested_label"; then
@@ -166,11 +166,11 @@ jobs:
                 if gh pr edit "$url" --add-label "$labels_to_add_tested"; then
                   labels_added=$(echo "$labels_to_add_tested" | tr ',' '\n')
                   labels=$(printf "%s\n%s\n" "$labels" "$labels_added" | sed '/^$/d' | sort -fu)
-                  tested_branches_list=$(echo "$labels_to_add_tested" | grep -oP '(?<=Tested for )(?:msft-)?\d{6}(?= Branch)' | paste -sd ',' -)
+                  tested_branches_list=$(echo "$labels_to_add_tested" | grep -oiP '(?<=Tested for )(?:msft-)?\d{6}(?= Branch)' | paste -sd ',' -)
                   comment_pr "$url" "The **Tested branch** section has been ticked and **Test result** is provided for branch(es): $tested_branches_list. Added label(s): $labels_to_add_tested."
                   echo "Added tested label(s) for $url: $labels_to_add_tested" >> cherry_pick_scan.log
                 else
-                  existing_failure_comments=$(gh api "repos/$repo/issues/$pr_number/comments" --jq '[.[] | select(.user.login == "mssonicbld" and (.body | test("Failed to add tested label"; "i")))] | length' 2>/dev/null || echo "0")
+                  existing_failure_comments=$(gh api "repos/$repo/issues/$pr_number/comments" --paginate --jq '.[] | select(.user.login == "mssonicbld" and (.body | test("Failed to add tested label"; "i"))) | .id' 2>/dev/null | wc -l | tr -d '[:space:]')
                   if [[ "$existing_failure_comments" == "0" ]]; then
                     comment_pr "$url" "@yijingyan2 @lunyue-ms Failed to add tested label(s): $labels_to_add_tested. The label(s) may not exist. Please check manually."
                   fi
@@ -179,7 +179,7 @@ jobs:
               fi
               if [[ -n "$labels_to_remove_tested" ]]; then
                 if gh pr edit "$url" --remove-label "$labels_to_remove_tested"; then
-                  removed_tested_branches=$(echo "$labels_to_remove_tested" | grep -oP '(?<=Tested for )(?:msft-)?\d{6}(?= Branch)' | paste -sd ',' -)
+                  removed_tested_branches=$(echo "$labels_to_remove_tested" | grep -oiP '(?<=Tested for )(?:msft-)?\d{6}(?= Branch)' | paste -sd ',' -)
                   comment_pr "$url" "The **Tested branch** tick or **Test result** has been removed for branch(es): $removed_tested_branches. Removed label(s): $labels_to_remove_tested."
                   echo "Removed tested label(s) for $url: $labels_to_remove_tested" >> cherry_pick_scan.log
                 else
@@ -187,7 +187,7 @@ jobs:
                 fi
               fi
               if [[ -n "$missing_tested_for" ]]; then
-                existing_missing_comment_bodies=$(gh api "repos/$repo/issues/$pr_number/comments" --jq '[.[] | select(.user.login == "mssonicbld" and (.body | test("missing required test information"; "i"))) | .body] | join("\n")' 2>/dev/null || echo "")
+                existing_missing_comment_bodies=$(gh api "repos/$repo/issues/$pr_number/comments" --paginate --jq '.[] | select(.user.login == "mssonicbld" and (.body | test("missing required test information"; "i"))) | .body' 2>/dev/null | tr '\n' ' ')
                 uncovered_branches=""
                 while IFS= read -r mb; do
                   [[ -z "$mb" ]] && continue


### PR DESCRIPTION
- The bot kept posting the same "missing required test information" comment over and over (see sonic-buildimage#27889 — same 202605 message every few hours). Turns out the dedup check that's supposed to skip if it already commented calls `gh api .../comments` without `--paginate`, so it only looks at the first 30 comments. Once a PR has more comments than that, it never finds its own earlier comment and just keeps posting. The "Failed to add tested label" dedup had the same problem.
Fixed both by adding `--paginate` and aggregating across pages in bash.

 - `grep -P` is case-sensitive and requires a capital **`Branch`**. When a PR carries backport-request labels written with lowercase `branch` (e.g. `Request for 202511 branch`, `Request for 202605 branch` ih sonic-mgmt repo), the gate matches nothing, so the entire Tested-branch/Test-result block is skipped — the bot never adds `Tested for … Branch` labels and never comments, even when the tester ticked the box and provided a test result. 
Use `grep -iP` so lowercase-`branch` labels also satisfy the gate, letting the tested-label add/remove/comment logic run as intended

