### PR TITLE
[ci] fix: handle multiple origin PR URLs in cherry-pick scanning

### DIFF
--- a/azure-pipelines/automation-pr-scan.yml
+++ b/azure-pipelines/automation-pr-scan.yml
@@ -79,7 +79,7 @@ jobs:
               if echo "$title" | grep -Fq "Upgrade SONiC package Versions" && ! echo $pr | jq -e '.labels[]? | select(.name == "automerge")' > /dev/null; then
                 gh pr edit $url -R $repo --add-label automerge
               fi
-              origin_pr_url=$(echo $pr | jq .comments[].body -r | grep '^Original PR: ' | grep -Eo "https://github.com/.*/pull/[0-9]*" || true)
+              origin_pr_url=$(echo $pr | jq .comments[].body -r | grep '^Original PR: ' | grep -Eo "https://github.com/.*/pull/[0-9]*" | head -n1 || true)
               created_at=$(echo $pr | jq .createdAt -r)
               checks=$(echo $pr | jq .statusCheckRollup)
               base_ref=$(echo $pr | jq .baseRefName -r)


### PR DESCRIPTION
When a cherry-pick PR has been retried, the bot may have posted multiple comments each starting with `"Original PR: "`. 
The `origin_pr_url` extraction collects all matching URLs, resulting in a newline-separated multi-line value. When used unquoted in `gh pr edit $origin_pr_url` and `gh pr view $origin_pr_url`, word splitting passes each URL as a separate positional argument, causing `gh` to error with `accepts at most 1 arg(s), received 2`.

Fix: Add `| head -n1` to the origin_pr_url extraction so only the first matching URL is captured.