### PR TITLE
validates the pipeline runs on commit-validation branch to aviod affe…

### DIFF
--- a/azure-pipelines/scripts/update-commit-validation-branch.py
+++ b/azure-pipelines/scripts/update-commit-validation-branch.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+def github_request(url, token, method='GET', payload=None):
+  data = json.dumps(payload).encode('utf-8') if payload is not None else None
+  request = urllib.request.Request(
+    url,
+    data=data,
+    method=method,
+    headers={
+      'Accept': 'application/vnd.github+json',
+      'Authorization': f'Bearer {token}',
+      'Content-Type': 'application/json',
+      'User-Agent': 'sonic-pipelines',
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  )
+  with urllib.request.urlopen(request, timeout=30) as response:
+    return json.load(response)
+
+
+def update_branch(repository, branch, commit, token):
+  if not branch or branch == 'master' or branch.startswith('refs/'):
+    raise ValueError('branch must be a short, non-master branch name')
+  encoded_branch = urllib.parse.quote(branch, safe='/')
+  lookup_url = (
+    f'https://api.github.com/repos/{repository}/git/ref/heads/{encoded_branch}'
+  )
+  update_url = (
+    f'https://api.github.com/repos/{repository}/git/refs/heads/{encoded_branch}'
+  )
+  try:
+    reference = github_request(lookup_url, token)
+  except urllib.error.HTTPError as error:
+    if error.code != 404:
+      raise
+    try:
+      github_request(
+        f'https://api.github.com/repos/{repository}/git/refs',
+        token,
+        method='POST',
+        payload={'ref': f'refs/heads/{branch}', 'sha': commit}
+      )
+      return 'created'
+    except urllib.error.HTTPError as create_error:
+      if create_error.code != 422:
+        raise
+      reference = github_request(lookup_url, token)
+
+  if reference.get('object', {}).get('sha') == commit:
+    return 'unchanged'
+
+  github_request(
+    update_url,
+    token,
+    method='PATCH',
+    payload={'sha': commit, 'force': True}
+  )
+  return 'updated'
+
+
+def main():
+  parser = argparse.ArgumentParser(
+    description='Create or update a GitHub branch at a specific commit.'
+  )
+  parser.add_argument('--repository', required=True)
+  parser.add_argument('--branch', required=True)
+  parser.add_argument('--commit', required=True)
+  args = parser.parse_args()
+
+  if args.branch == 'master' or args.branch.startswith('refs/'):
+    parser.error('branch must be a short, non-master branch name')
+  token = os.environ.get('GH_TOKEN')
+  if not token:
+    parser.error('GH_TOKEN is required')
+
+  action = update_branch(
+    args.repository, args.branch, args.commit, token
+  )
+  print(
+    f'{action.capitalize()} {args.repository}:{args.branch} at {args.commit}'
+  )
+
+
+if __name__ == '__main__':
+  main()

--- a/azure-pipelines/submodule-pipelines-trigger.md
+++ b/azure-pipelines/submodule-pipelines-trigger.md
@@ -12,10 +12,11 @@ commits.
 
 1. **Resolve the buildimage commit.** Finds the latest *successful* run of the
    `sonic-buildimage` official build pipeline (`VSbBuildPipelineId`, default `142`) on
-   `master` and reads the commit (`sourceVersion`) it built.
+   `buildimageBranch` (default `master`) and reads the commit (`sourceVersion`) it built.
 2. **Trigger submodules, level by level.** For each dependency level, in order, it resolves
-   every submodule's pinned SHA at that buildimage commit and queues the matching build
-   pipeline. A level must fully succeed before the next level starts.
+   every submodule's pinned SHA, creates or force-updates the repository's non-master
+   validation branch at that SHA, and queues the matching build pipeline on that branch.
+   A level must fully succeed before the next level starts.
 3. **Retry on failure.** If a triggered run fails, it retries the *failed stages in the same
    run* (via the Azure DevOps REST timeline + stage `retry` API) once before giving up.
 4. **Open a validation PR.** After all levels pass, the `CreatePR` stage collects the
@@ -26,7 +27,7 @@ commits.
 
 ```
 ResolveCommit
-   └─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
+   └─> prerequisites ─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
 ```
 
 Each `levelN` stage depends on `ResolveCommit` (to read the buildimage SHA output) **and**
@@ -40,14 +41,16 @@ Within a level, all submodule pipelines run **in parallel** (one job each).
 
 | Level | Submodules (path → pipeline id) |
 |-------|----------------------------------|
+| prerequisites | `docker_slave_trixie` (3006), `docker_slave_bookworm` (1148), `sonic-buildimage-ubuntu22.04` (1055) |
 | level0 | `common_libs` (465), `src/sonic-dash-api` (1318) |
 | level1 | `platform/vpp` (1016), `src/sonic-swss-common` (9), `src/sonic-platform-common` (42), `src/sonic-platform-daemons` (41), `src/sonic-host-services` (935), `src/sonic-mgmt-framework` (130), `src/sonic-mgmt-common` (127), `src/sonic-snmpagent` (106), `src/sonic-dbsyncd` (110) |
 | level2 | `src/sonic-sairedis` (12), `src/sonic-gnmi` (934), `src/sonic-utilities` (55), `src/sonic-bmp` (1565), `src/sonic-dash-ha` (2351), `src/linkmgrd` (388), `src/dhcpmon` (901), `src/dhcprelay` (487), `src/sonic-stp` (84), `src/wpasupplicant/sonic-wpa-supplicant` (5) |
 | level3 | `src/sonic-swss` (15) |
 
-> `common_libs` is special-cased: it is not a submodule gitlink, so its commit is the
-> buildimage commit itself (`git rev-parse HEAD`). All other entries resolve their pinned
-> commit via `git ls-tree <buildimageSha> <path>`.
+> `docker_slave_trixie`, `docker_slave_bookworm`, `sonic_buildimage_ubuntu22_04`, and
+> `common_libs` are buildimage pipelines rather than submodule gitlinks, so they use the
+> buildimage commit itself (`git rev-parse HEAD`). All other entries resolve their pinned commit via
+> `git ls-tree <buildimageSha> <path>`.
 
 ## Parameters
 
@@ -55,6 +58,8 @@ Within a level, all submodule pipelines run **in parallel** (one job each).
 |------|------|---------|-------------|
 | `targetProject` | string | `build` | Azure DevOps project that hosts the submodule pipelines. |
 | `VSbBuildPipelineId` | string | `142` | Pipeline id of the `sonic-buildimage` official build, used to resolve the reference commit. |
+| `buildimageBranch` | string | `master` | Branch used to resolve the buildimage commit and target the validation PR. |
+| `validationBranch` | string | empty (required) | Non-master branch used to queue component pipelines. Empty and `master` values are rejected before any component run is queued. |
 | `levels` | object | see above | Ordered list of levels; each has `name`, `dependsOn` (list), and a `pipelines` map of `submodule-path: pipeline-id`. |
 
 ## How a submodule job works
@@ -64,8 +69,9 @@ For each `submodule-path: pipeline-id` in a level:
 1. Clone `sonic-buildimage`, check out the resolved buildimage SHA, and read the submodule's
    pinned commit. A missing pinned commit is treated as a **configuration error** and fails
    the job (wrong path or a removed/renamed submodule).
-2. Queue the submodule pipeline at that commit
-   (`az pipelines run --id <pipeline-id> --commit-id <sha> --branch refs/heads/master`).
+2. Resolve the pipeline's GitHub repository and create or force-update
+   `validationBranch` at the pinned commit. Queue the submodule pipeline at that commit
+   (`az pipelines run --id <pipeline-id> --commit-id <sha> --branch refs/heads/<validationBranch>`).
 3. Poll run status every 600s until `completed`; treat `succeeded` **or**
    `partiallySucceeded` as pass.
 4. On failure, retry the failed stages in the same run once, then wait for the retried
@@ -84,8 +90,9 @@ The pipeline expects the following to already exist in the Azure DevOps org / ta
   every `AzureCLI@2` task. It authenticates to Azure DevOps via an AAD access token for the
   Azure DevOps resource (`499b84ac-1321-427f-aa17-267ca6975798`).
 - **Variable group** `sonicbld` containing `GITHUB-TOKEN` — a GitHub token for the
-  `mssonicbld` bot with push access to the `mssonicbld/sonic-buildimage` fork and permission
-  to open PRs against `sonic-net/sonic-buildimage`.
+   `mssonicbld` bot with Contents write access to the component `sonic-net` repositories,
+   push access to the `mssonicbld/sonic-buildimage` fork, and permission to open PRs against
+   `sonic-net/sonic-buildimage`.
 - The **`mssonicbld/sonic-buildimage`** fork (PR head branch is pushed there).
 - The **`automerge`** label must exist in `sonic-net/sonic-buildimage`.
 - Agent pool **`sonic-ubuntu-1c`** with enough parallelism to cover the widest level
@@ -96,7 +103,8 @@ The pipeline expects the following to already exist in the Azure DevOps org / ta
 
 Trigger the pipeline manually (or on a schedule) from Azure DevOps. To override a default,
 supply the parameter at queue time — e.g. point at a different reference build with
-`VSbBuildPipelineId`, or target a different project with `targetProject`.
+`VSbBuildPipelineId`, queue component runs against another branch with
+`validationBranch`, or target a different project with `targetProject`.
 
 ## Adding or reordering a submodule
 
@@ -111,7 +119,8 @@ Edit the `levels` parameter default:
 ## The validation PR
 
 `CreatePR` assembles all published `path=sha` records, commits them to a
-`validated-submodule-commits` tracking file on branch `validated-submodules` in the
+`validated-submodule-commits` tracking file on branch
+`validated-submodules-<buildimageBranch>-via-<validationBranch>` in the
 `mssonicbld` fork, and opens (or updates) a PR titled
 `[validated] Submodule pipeline runs passed for <buildimageSha>` with the `automerge` label.
 If a PR for the branch already exists, the branch is force-pushed and the existing PR is

--- a/azure-pipelines/submodule-pipelines-trigger.md
+++ b/azure-pipelines/submodule-pipelines-trigger.md
@@ -10,9 +10,8 @@ commits.
 
 ## What it does
 
-1. **Resolve the buildimage commit.** Finds the latest *successful* run of the
-   `sonic-buildimage` official build pipeline (`VSbBuildPipelineId`, default `142`) on
-   `master` and reads the commit (`sourceVersion`) it built.
+1. **Resolve the buildimage commit.** Reads the latest commit on the `sonic-buildimage`
+   `master` branch and uses that exact SHA throughout the run.
 2. **Trigger submodules, level by level.** For each dependency level, in order, it resolves
    every submodule's pinned SHA, creates or force-updates the repository's non-master
    validation branch at that SHA, and queues the matching build pipeline on that branch.
@@ -27,12 +26,12 @@ commits.
 
 ```
 ResolveCommit
-   └─> prerequisites ─> buildimage ─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
+   └─> prerequisites ─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
 ```
 
-Each validation stage depends on `ResolveCommit` (to read the buildimage SHA output) **and**
-on the previous stage (to enforce ordering). `CreatePR` depends on `ResolveCommit` and all
-validation stages, and runs only on `succeeded()`.
+Each `levelN` stage depends on `ResolveCommit` (to read the buildimage SHA output) **and**
+on the previous level (to enforce ordering). `CreatePR` depends on `ResolveCommit` and all
+levels, and runs only on `succeeded()`.
 
 ## Dependency levels
 
@@ -41,26 +40,24 @@ Within a level, all submodule pipelines run **in parallel** (one job each).
 
 | Level | Submodules (path → pipeline id) |
 |-------|----------------------------------|
-| prerequisites | `docker_slave_trixie` (3006), `docker_slave_bookworm` (1148), `sonic_buildimage_ubuntu22_04` (1055) |
-| buildimage | `buildimage_vs` (142) |
+| prerequisites | `docker_slave_trixie` (3006), `docker_slave_bookworm` (1148), `sonic-buildimage-ubuntu22.04` (1055) |
 | level0 | `common_libs` (465), `src/sonic-dash-api` (1318) |
 | level1 | `platform/vpp` (1016), `src/sonic-swss-common` (9), `src/sonic-platform-common` (42), `src/sonic-platform-daemons` (41), `src/sonic-host-services` (935), `src/sonic-mgmt-framework` (130), `src/sonic-mgmt-common` (127), `src/sonic-snmpagent` (106), `src/sonic-dbsyncd` (110) |
 | level2 | `src/sonic-sairedis` (12), `src/sonic-gnmi` (934), `src/sonic-utilities` (55), `src/sonic-bmp` (1565), `src/sonic-dash-ha` (2351), `src/linkmgrd` (388), `src/dhcpmon` (901), `src/dhcprelay` (487), `src/sonic-stp` (84), `src/wpasupplicant/sonic-wpa-supplicant` (5) |
 | level3 | `src/sonic-swss` (15) |
 
-> `docker_slave_trixie`, `docker_slave_bookworm`, `sonic_buildimage_ubuntu22_04`,
-> `buildimage_vs`, and `common_libs` are buildimage pipelines rather than submodule
-> gitlinks, so they use the buildimage commit itself (`git rev-parse HEAD`). All other
-> entries resolve their pinned commit via `git ls-tree <buildimageSha> <path>`.
+> `docker_slave_trixie`, `docker_slave_bookworm`, `sonic_buildimage_ubuntu22_04`, and
+> `common_libs` are buildimage pipelines rather than submodule gitlinks, so they use the
+> buildimage commit itself (`git rev-parse HEAD`). All other entries resolve their pinned commit via
+> `git ls-tree <buildimageSha> <path>`.
 
 ## Parameters
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | `targetProject` | string | `build` | Azure DevOps project that hosts the submodule pipelines. |
-| `VSbBuildPipelineId` | string | `142` | Pipeline id of the `sonic-buildimage` official build, used to resolve the reference commit. |
 | `validationBranch` | string | `commit-validation` | Non-master branch used to queue component pipelines. Empty and `master` values are rejected before any component run is queued. |
-| `levels` | object | see above | Ordered list of levels; each has `name`, `dependsOn` (list), a `pipelines` map of `submodule-path: pipeline-id`, and may override `timeoutInMinutes`. |
+| `levels` | object | see above | Ordered list of levels; each has `name`, `dependsOn` (list), and a `pipelines` map of `submodule-path: pipeline-id`. |
 
 ## How a submodule job works
 
@@ -79,9 +76,8 @@ For each `submodule-path: pipeline-id` in a level:
 5. Publish the validated `path=sha` record as a pipeline artifact
    (`commits_<level>_<safe-path>`) for the `CreatePR` stage.
 
-Jobs use `timeoutInMinutes: 540` (9h) by default — this is the ceiling for a single
-component build plus queue/poll time. The `buildimage` stage overrides the timeout to
-`900` minutes (15h) for its `buildimage_vs` job.
+Each job has `timeoutInMinutes: 540` (9h) — this is the ceiling for a single submodule
+build plus queue/poll time.
 
 ## Requirements
 
@@ -103,8 +99,7 @@ The pipeline expects the following to already exist in the Azure DevOps org / ta
 ## Running it
 
 Trigger the pipeline manually (or on a schedule) from Azure DevOps. To override a default,
-supply the parameter at queue time — e.g. point at a different reference build with
-`VSbBuildPipelineId`, queue component runs against another branch with
+supply the parameter at queue time — e.g. queue component runs against another branch with
 `validationBranch`, or target a different project with `targetProject`.
 
 ## Adding or reordering a submodule
@@ -120,8 +115,8 @@ Edit the `levels` parameter default:
 ## The validation PR
 
 `CreatePR` assembles all published `path=sha` records, commits them to a
-`validated-submodule-commits` tracking file on the fixed `validated-submodules` branch in
-the `mssonicbld` fork, and opens (or updates) a PR targeting `master` titled
+`validated-submodule-commits` tracking file on the `validated-submodules` branch in the
+`mssonicbld` fork, and opens (or updates) a PR titled
 `[validated] Submodule pipeline runs passed for <buildimageSha>` with the `automerge` label.
 If a PR for the branch already exists, the branch is force-pushed and the existing PR is
 re-labeled instead of failing.

--- a/azure-pipelines/submodule-pipelines-trigger.md
+++ b/azure-pipelines/submodule-pipelines-trigger.md
@@ -12,7 +12,7 @@ commits.
 
 1. **Resolve the buildimage commit.** Finds the latest *successful* run of the
    `sonic-buildimage` official build pipeline (`VSbBuildPipelineId`, default `142`) on
-   `buildimageBranch` (default `master`) and reads the commit (`sourceVersion`) it built.
+   `master` and reads the commit (`sourceVersion`) it built.
 2. **Trigger submodules, level by level.** For each dependency level, in order, it resolves
    every submodule's pinned SHA, creates or force-updates the repository's non-master
    validation branch at that SHA, and queues the matching build pipeline on that branch.
@@ -27,12 +27,12 @@ commits.
 
 ```
 ResolveCommit
-   └─> prerequisites ─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
+   └─> prerequisites ─> buildimage ─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
 ```
 
-Each `levelN` stage depends on `ResolveCommit` (to read the buildimage SHA output) **and**
-on the previous level (to enforce ordering). `CreatePR` depends on `ResolveCommit` and all
-levels, and runs only on `succeeded()`.
+Each validation stage depends on `ResolveCommit` (to read the buildimage SHA output) **and**
+on the previous stage (to enforce ordering). `CreatePR` depends on `ResolveCommit` and all
+validation stages, and runs only on `succeeded()`.
 
 ## Dependency levels
 
@@ -41,16 +41,17 @@ Within a level, all submodule pipelines run **in parallel** (one job each).
 
 | Level | Submodules (path → pipeline id) |
 |-------|----------------------------------|
-| prerequisites | `docker_slave_trixie` (3006), `docker_slave_bookworm` (1148), `sonic-buildimage-ubuntu22.04` (1055) |
+| prerequisites | `docker_slave_trixie` (3006), `docker_slave_bookworm` (1148), `sonic_buildimage_ubuntu22_04` (1055) |
+| buildimage | `buildimage_vs` (142) |
 | level0 | `common_libs` (465), `src/sonic-dash-api` (1318) |
 | level1 | `platform/vpp` (1016), `src/sonic-swss-common` (9), `src/sonic-platform-common` (42), `src/sonic-platform-daemons` (41), `src/sonic-host-services` (935), `src/sonic-mgmt-framework` (130), `src/sonic-mgmt-common` (127), `src/sonic-snmpagent` (106), `src/sonic-dbsyncd` (110) |
 | level2 | `src/sonic-sairedis` (12), `src/sonic-gnmi` (934), `src/sonic-utilities` (55), `src/sonic-bmp` (1565), `src/sonic-dash-ha` (2351), `src/linkmgrd` (388), `src/dhcpmon` (901), `src/dhcprelay` (487), `src/sonic-stp` (84), `src/wpasupplicant/sonic-wpa-supplicant` (5) |
 | level3 | `src/sonic-swss` (15) |
 
-> `docker_slave_trixie`, `docker_slave_bookworm`, `sonic_buildimage_ubuntu22_04`, and
-> `common_libs` are buildimage pipelines rather than submodule gitlinks, so they use the
-> buildimage commit itself (`git rev-parse HEAD`). All other entries resolve their pinned commit via
-> `git ls-tree <buildimageSha> <path>`.
+> `docker_slave_trixie`, `docker_slave_bookworm`, `sonic_buildimage_ubuntu22_04`,
+> `buildimage_vs`, and `common_libs` are buildimage pipelines rather than submodule
+> gitlinks, so they use the buildimage commit itself (`git rev-parse HEAD`). All other
+> entries resolve their pinned commit via `git ls-tree <buildimageSha> <path>`.
 
 ## Parameters
 
@@ -58,9 +59,8 @@ Within a level, all submodule pipelines run **in parallel** (one job each).
 |------|------|---------|-------------|
 | `targetProject` | string | `build` | Azure DevOps project that hosts the submodule pipelines. |
 | `VSbBuildPipelineId` | string | `142` | Pipeline id of the `sonic-buildimage` official build, used to resolve the reference commit. |
-| `buildimageBranch` | string | `master` | Branch used to resolve the buildimage commit and target the validation PR. |
-| `validationBranch` | string | empty (required) | Non-master branch used to queue component pipelines. Empty and `master` values are rejected before any component run is queued. |
-| `levels` | object | see above | Ordered list of levels; each has `name`, `dependsOn` (list), and a `pipelines` map of `submodule-path: pipeline-id`. |
+| `validationBranch` | string | `commit-validation` | Non-master branch used to queue component pipelines. Empty and `master` values are rejected before any component run is queued. |
+| `levels` | object | see above | Ordered list of levels; each has `name`, `dependsOn` (list), a `pipelines` map of `submodule-path: pipeline-id`, and may override `timeoutInMinutes`. |
 
 ## How a submodule job works
 
@@ -79,8 +79,9 @@ For each `submodule-path: pipeline-id` in a level:
 5. Publish the validated `path=sha` record as a pipeline artifact
    (`commits_<level>_<safe-path>`) for the `CreatePR` stage.
 
-Each job has `timeoutInMinutes: 540` (9h) — this is the ceiling for a single submodule
-build plus queue/poll time.
+Jobs use `timeoutInMinutes: 540` (9h) by default — this is the ceiling for a single
+component build plus queue/poll time. The `buildimage` stage overrides the timeout to
+`900` minutes (15h) for its `buildimage_vs` job.
 
 ## Requirements
 
@@ -119,9 +120,8 @@ Edit the `levels` parameter default:
 ## The validation PR
 
 `CreatePR` assembles all published `path=sha` records, commits them to a
-`validated-submodule-commits` tracking file on branch
-`validated-submodules-<buildimageBranch>-via-<validationBranch>` in the
-`mssonicbld` fork, and opens (or updates) a PR titled
+`validated-submodule-commits` tracking file on the fixed `validated-submodules` branch in
+the `mssonicbld` fork, and opens (or updates) a PR targeting `master` titled
 `[validated] Submodule pipeline runs passed for <buildimageSha>` with the `automerge` label.
 If a PR for the branch already exists, the branch is force-pushed and the existing PR is
 re-labeled instead of failing.

--- a/azure-pipelines/submodule-pipelines-trigger.md
+++ b/azure-pipelines/submodule-pipelines-trigger.md
@@ -12,13 +12,15 @@ commits.
 
 1. **Resolve the buildimage commit.** Reads the latest commit on the `sonic-buildimage`
    `master` branch and uses that exact SHA throughout the run.
-2. **Trigger submodules, level by level.** For each dependency level, in order, it resolves
-   every submodule's pinned SHA, creates or force-updates the repository's non-master
-   validation branch at that SHA, and queues the matching build pipeline on that branch.
-   A level must fully succeed before the next level starts.
-3. **Retry on failure.** If a triggered run fails, it retries the *failed stages in the same
+2. **Prepare validation branches.** Resolves every configured pipeline's GitHub repository,
+   then creates or force-updates all non-master validation branches to their pinned commits.
+   No component pipeline is queued until every repository branch is ready, so pipelines that
+   checkout other component repositories see the commits from the same validation run.
+3. **Trigger submodules, level by level.** Queues each dependency level against the prepared
+   validation branches. A level must fully succeed before the next level starts.
+4. **Retry on failure.** If a triggered run fails, it retries the *failed stages in the same
    run* (via the Azure DevOps REST timeline + stage `retry` API) once before giving up.
-4. **Open a validation PR.** After all levels pass, the `CreatePR` stage collects the
+5. **Open a validation PR.** After all levels pass, the `CreatePR` stage collects the
    validated commits, writes them to a tracking file, and opens a PR to
    `sonic-net/sonic-buildimage` (from the `mssonicbld` fork) with the **`automerge`** label.
 
@@ -26,12 +28,12 @@ commits.
 
 ```
 ResolveCommit
-   └─> prerequisites ─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
+   └─> PrepareBranches ─> prerequisites ─> buildimage ─> level0 ─> level1 ─> level2 ─> level3 ─> CreatePR
 ```
 
-Each `levelN` stage depends on `ResolveCommit` (to read the buildimage SHA output) **and**
-on the previous level (to enforce ordering). `CreatePR` depends on `ResolveCommit` and all
-levels, and runs only on `succeeded()`.
+Every trigger stage depends on `PrepareBranches`, `ResolveCommit` (to read the buildimage SHA
+output), and its configured predecessor (to enforce ordering). `CreatePR` depends on
+`ResolveCommit` and all levels, and runs only on `succeeded()`.
 
 ## Dependency levels
 
@@ -66,8 +68,8 @@ For each `submodule-path: pipeline-id` in a level:
 1. Clone `sonic-buildimage`, check out the resolved buildimage SHA, and read the submodule's
    pinned commit. A missing pinned commit is treated as a **configuration error** and fails
    the job (wrong path or a removed/renamed submodule).
-2. Resolve the pipeline's GitHub repository and create or force-update
-   `validationBranch` at the pinned commit. Queue the submodule pipeline at that commit
+2. Queue the submodule pipeline at that commit using the branch prepared by the
+   `PrepareBranches` stage
    (`az pipelines run --id <pipeline-id> --commit-id <sha> --branch refs/heads/<validationBranch>`).
 3. Poll run status every 600s until `completed`; treat `succeeded` **or**
    `partiallySucceeded` as pass.

--- a/azure-pipelines/submodule-pipelines-trigger.yml
+++ b/azure-pipelines/submodule-pipelines-trigger.yml
@@ -9,6 +9,9 @@
 trigger: none
 pr: none
 
+variables:
+- group: sonicbld
+
 parameters:
 - name: targetProject
   type: string
@@ -16,11 +19,25 @@ parameters:
 - name: VSbBuildPipelineId
   type: string
   default: '142'
+- name: validationBranch
+  type: string
+  default: 'commit-validation'
 - name: levels
   type: object
   default:
-  - name: level0
+  - name: prerequisites
     dependsOn: [ResolveCommit]
+    pipelines:
+      docker_slave_trixie: '3006'
+      docker_slave_bookworm: '1148'
+      sonic_buildimage_ubuntu22_04: '1055'
+  - name: buildimage
+    dependsOn: [ResolveCommit, prerequisites]
+    timeoutInMinutes: 900
+    pipelines:
+      buildimage_vs: '142'
+  - name: level0
+    dependsOn: [ResolveCommit, buildimage]
     pipelines:
       common_libs: '465'
       src/sonic-dash-api: '1318'
@@ -104,29 +121,42 @@ stages:
       - job: trigger_${{ replace(replace(pipeline.key, '/', '_'), '-', '_') }}
         pool: sonic-ubuntu-1c
         displayName: '${{ pipeline.key }}'
-        timeoutInMinutes: 540
+        timeoutInMinutes: ${{ coalesce(level.timeoutInMinutes, 540) }}
         steps:
-        - checkout: none
+        - checkout: self
         - bash: |
             set -e
             command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           displayName: 'Install Azure CLI'
         - task: AzureCLI@2
           displayName: 'Trigger ${{ pipeline.key }} pipeline'
+          env:
+            GH_TOKEN: $(GITHUB-TOKEN)
           inputs:
             azureSubscription: 'mssonic-automation-umi'
             scriptType: bash
             scriptLocation: inlineScript
             inlineScript: |
-              set -e
+              set -euo pipefail
               az extension add --name azure-devops --yes
               export AZURE_DEVOPS_EXT_PAT=$(az account get-access-token \
                 --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+              VALIDATION_BRANCH='${{ parameters.validationBranch }}'
+              VALIDATION_BRANCH="${VALIDATION_BRANCH#refs/heads/}"
+              if [ -z "$VALIDATION_BRANCH" ] || [ "$VALIDATION_BRANCH" = master ]; then
+                echo "Refusing to update or queue master; validationBranch must be non-master"
+                exit 1
+              fi
+              VALIDATION_BRANCH_REF="refs/heads/$VALIDATION_BRANCH"
+              rm -rf buildimage
               git clone https://github.com/sonic-net/sonic-buildimage buildimage
               cd buildimage
               git checkout $(buildimageSha)
-              mkdir -p "$(Pipeline.Workspace)/commits"
-              if [ "${{ pipeline.key }}" = "common_libs" ]; then
+              if [ "${{ pipeline.key }}" = "common_libs" ] || \
+                [ "${{ pipeline.key }}" = "docker_slave_trixie" ] || \
+                [ "${{ pipeline.key }}" = "docker_slave_bookworm" ] || \
+                [ "${{ pipeline.key }}" = "sonic_buildimage_ubuntu22_04" ] || \
+                [ "${{ pipeline.key }}" = "buildimage_vs" ]; then
                 SHA=$(git rev-parse HEAD)
               else
                 SHA=$(git ls-tree HEAD '${{ pipeline.key }}' | awk '{print $3}')
@@ -136,12 +166,19 @@ stages:
                 exit 1
               fi
               echo "Pinned commit for ${{ pipeline.key }}: $SHA"
+              REPOSITORY_TYPE=$(az pipelines show --id ${{ pipeline.value }} --project ${{ parameters.targetProject }} --organization "$(System.CollectionUri)" --query repository.type -o tsv)
+              REPOSITORY_NAME=$(az pipelines show --id ${{ pipeline.value }} --project ${{ parameters.targetProject }} --organization "$(System.CollectionUri)" --query repository.name -o tsv)
+              if [ "$REPOSITORY_TYPE" != GitHub ] || [ -z "$REPOSITORY_NAME" ]; then
+                echo "Pipeline ${{ pipeline.value }} does not have a supported GitHub repository"
+                exit 1
+              fi
+              python3 "$(Build.SourcesDirectory)/azure-pipelines/scripts/update-commit-validation-branch.py" --repository "$REPOSITORY_NAME" --branch "$VALIDATION_BRANCH" --commit "$SHA"
               run_pipeline() {
                 RUN_ID=$(az pipelines run \
                   --id ${{ pipeline.value }} \
                   --project ${{ parameters.targetProject }} \
                   --commit-id $SHA \
-                  --branch refs/heads/master \
+                  --branch "$VALIDATION_BRANCH_REF" \
                   --organization "$(System.CollectionUri)" \
                   --query id -o tsv)
                 if [ -z "$RUN_ID" ]; then
@@ -232,8 +269,11 @@ stages:
               fi
               # Publish the validated commit as a pipeline artifact for the CreatePR stage
               SAFE_KEY=$(echo '${{ pipeline.key }}' | tr '/' '_')
-              echo "${{ pipeline.key }}=$SHA" > "$(Pipeline.Workspace)/commits/${SAFE_KEY}"
-        - publish: $(Pipeline.Workspace)/commits
+              COMMIT_DIR="$(Agent.TempDirectory)/commit-record"
+              rm -rf "$COMMIT_DIR"
+              mkdir -p "$COMMIT_DIR"
+              echo "${{ pipeline.key }}=$SHA" > "$COMMIT_DIR/${SAFE_KEY}"
+        - publish: $(Agent.TempDirectory)/commit-record
           artifact: commits_${{ level.name }}_${{ replace(pipeline.key, '/', '_') }}
           displayName: 'Publish commit record'
   
@@ -243,8 +283,6 @@ stages:
   - ${{ each level in parameters.levels }}:
     - ${{ level.name }}
   condition: succeeded()
-  variables:
-  - group: sonicbld
   jobs:
   - job: CreatePR
     pool: sonic-ubuntu-1c
@@ -284,6 +322,7 @@ stages:
           echo "$RECORD"
 
           # Clone latest master to base the PR on
+          rm -rf buildimage
           git clone --depth=1 https://github.com/sonic-net/sonic-buildimage buildimage
           cd buildimage
           git config user.email "sonicbld@microsoft.com"

--- a/azure-pipelines/submodule-pipelines-trigger.yml
+++ b/azure-pipelines/submodule-pipelines-trigger.yml
@@ -2,8 +2,8 @@
 # sonic-buildimage. Level 0 runs first; only after every Level-0 pipeline succeeds does
 # Level 1 start, then Level 2, and so on.
 #
-# Finds the latest successful run of the sonic-buildimage official pipeline, reads the
-# commit it built, then for each level resolves every submodule SHA pinned at that commit
+# Resolves the latest sonic-buildimage master commit, then for each level resolves every
+# submodule SHA pinned at that commit
 # and queues the matching pipeline, waiting for the whole level to finish before the next.
 
 trigger: none
@@ -16,9 +16,6 @@ parameters:
 - name: targetProject
   type: string
   default: build
-- name: VSbBuildPipelineId
-  type: string
-  default: '142'
 - name: validationBranch
   type: string
   default: 'commit-validation'
@@ -79,38 +76,16 @@ stages:
     steps:
     - checkout: none
     - bash: |
-        set -e
-        command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-      displayName: 'Install Azure CLI'
-    - task: AzureCLI@2
+        set -euo pipefail
+        SHA=$(git ls-remote https://github.com/sonic-net/sonic-buildimage.git refs/heads/master | awk '{print $1}')
+        if [ -z "$SHA" ]; then
+          echo "Could not resolve the latest sonic-buildimage master commit"
+          exit 1
+        fi
+        echo "Latest sonic-buildimage master commit: $SHA"
+        echo "##vso[task.setvariable variable=buildimageSha;isOutput=true]$SHA"
       name: resolve
-      displayName: 'Resolve sonic-buildimage commit'
-      inputs:
-        azureSubscription: 'mssonic-automation-umi'
-        scriptType: bash
-        scriptLocation: inlineScript
-        inlineScript: |
-          set -e
-          az extension add --name azure-devops --yes
-          AZURE_DEVOPS_EXT_PAT=$(az account get-access-token \
-            --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
-          export AZURE_DEVOPS_EXT_PAT
-          SHA=$(az pipelines runs list \
-            --pipeline-ids ${{ parameters.VSbBuildPipelineId }} \
-            --project ${{ parameters.targetProject }} \
-            --organization "$(System.CollectionUri)" \
-            --branch refs/heads/master \
-            --result succeeded \
-            --status completed \
-            --top 1 \
-            --query-order FinishTimeDesc \
-            --query "[0].sourceVersion" -o tsv)
-          if [ -z "$SHA" ]; then
-            echo "No successful run found for pipeline ${{ parameters.VSbBuildPipelineId }}"
-            exit 1
-          fi
-          echo "sonic-buildimage commit from latest successful run: $SHA"
-          echo "##vso[task.setvariable variable=buildimageSha;isOutput=true]$SHA"
+      displayName: 'Resolve latest sonic-buildimage master commit'
 - ${{ each level in parameters.levels }}:
   - stage: ${{ level.name }}
     dependsOn: ${{ level.dependsOn }}

--- a/azure-pipelines/submodule-pipelines-trigger.yml
+++ b/azure-pipelines/submodule-pipelines-trigger.yml
@@ -2,9 +2,8 @@
 # sonic-buildimage. Level 0 runs first; only after every Level-0 pipeline succeeds does
 # Level 1 start, then Level 2, and so on.
 #
-# Resolves the latest sonic-buildimage master commit, then for each level resolves every
-# submodule SHA pinned at that commit
-# and queues the matching pipeline, waiting for the whole level to finish before the next.
+# Resolves the latest sonic-buildimage master commit, updates every repository's validation
+# branch to its pinned commit, then queues the matching pipelines level by level.
 
 trigger: none
 pr: none
@@ -86,9 +85,68 @@ stages:
         echo "##vso[task.setvariable variable=buildimageSha;isOutput=true]$SHA"
       name: resolve
       displayName: 'Resolve latest sonic-buildimage master commit'
+- stage: PrepareBranches
+  dependsOn: ResolveCommit
+  variables:
+    buildimageSha: $[ stageDependencies.ResolveCommit.Resolve.outputs['resolve.buildimageSha'] ]
+  jobs:
+  - job: UpdateValidationBranches
+    pool: sonic-ubuntu-1c
+    steps:
+    - checkout: self
+    - bash: |
+        set -e
+        command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      displayName: 'Install Azure CLI'
+    - task: AzureCLI@2
+      displayName: 'Update all validation branches'
+      env:
+        GH_TOKEN: $(GITHUB-TOKEN)
+        LEVELS_JSON: ${{ convertToJson(parameters.levels) }}
+      inputs:
+        azureSubscription: 'mssonic-automation-umi'
+        scriptType: bash
+        scriptLocation: inlineScript
+        inlineScript: |
+          set -euo pipefail
+          az extension add --name azure-devops --yes
+          VALIDATION_BRANCH='${{ parameters.validationBranch }}'
+          VALIDATION_BRANCH="${VALIDATION_BRANCH#refs/heads/}"
+          if [ -z "$VALIDATION_BRANCH" ] || [ "$VALIDATION_BRANCH" = master ]; then
+            echo "Refusing to update master; validationBranch must be non-master"
+            exit 1
+          fi
+          rm -rf buildimage
+          git clone https://github.com/sonic-net/sonic-buildimage buildimage
+          cd buildimage
+          git checkout $(buildimageSha)
+          while IFS=$'\t' read -r PIPELINE_KEY PIPELINE_ID; do
+            case "$PIPELINE_KEY" in
+              common_libs|docker_slave_trixie|docker_slave_bookworm|sonic_buildimage_ubuntu22_04|buildimage_vs)
+                SHA=$(git rev-parse HEAD)
+                ;;
+              *)
+                SHA=$(git ls-tree HEAD "$PIPELINE_KEY" | awk '{print $3}')
+                ;;
+            esac
+            if [ -z "$SHA" ]; then
+              echo "No pinned commit found for $PIPELINE_KEY at $(buildimageSha); the path is likely wrong or the submodule was removed"
+              exit 1
+            fi
+            REPOSITORY_TYPE=$(az pipelines show --id "$PIPELINE_ID" --project ${{ parameters.targetProject }} --organization "$(System.CollectionUri)" --query repository.type -o tsv)
+            REPOSITORY_NAME=$(az pipelines show --id "$PIPELINE_ID" --project ${{ parameters.targetProject }} --organization "$(System.CollectionUri)" --query repository.name -o tsv)
+            if [ "$REPOSITORY_TYPE" != GitHub ] || [ -z "$REPOSITORY_NAME" ]; then
+              echo "Pipeline $PIPELINE_ID does not have a supported GitHub repository"
+              exit 1
+            fi
+            python3 "$(Build.SourcesDirectory)/azure-pipelines/scripts/update-commit-validation-branch.py" --repository "$REPOSITORY_NAME" --branch "$VALIDATION_BRANCH" --commit "$SHA"
+          done < <(python3 -c 'import json, os; levels = json.loads(os.environ["LEVELS_JSON"]); [print(f"{key}\t{value}") for level in levels for key, value in level["pipelines"].items()]')
 - ${{ each level in parameters.levels }}:
   - stage: ${{ level.name }}
-    dependsOn: ${{ level.dependsOn }}
+    dependsOn:
+    - PrepareBranches
+    - ${{ each dependency in level.dependsOn }}:
+      - ${{ dependency }}
     variables:
       buildimageSha: $[ stageDependencies.ResolveCommit.Resolve.outputs['resolve.buildimageSha'] ]
     jobs:
@@ -141,13 +199,6 @@ stages:
                 exit 1
               fi
               echo "Pinned commit for ${{ pipeline.key }}: $SHA"
-              REPOSITORY_TYPE=$(az pipelines show --id ${{ pipeline.value }} --project ${{ parameters.targetProject }} --organization "$(System.CollectionUri)" --query repository.type -o tsv)
-              REPOSITORY_NAME=$(az pipelines show --id ${{ pipeline.value }} --project ${{ parameters.targetProject }} --organization "$(System.CollectionUri)" --query repository.name -o tsv)
-              if [ "$REPOSITORY_TYPE" != GitHub ] || [ -z "$REPOSITORY_NAME" ]; then
-                echo "Pipeline ${{ pipeline.value }} does not have a supported GitHub repository"
-                exit 1
-              fi
-              python3 "$(Build.SourcesDirectory)/azure-pipelines/scripts/update-commit-validation-branch.py" --repository "$REPOSITORY_NAME" --branch "$VALIDATION_BRANCH" --commit "$SHA"
               run_pipeline() {
                 RUN_ID=$(az pipelines run \
                   --id ${{ pipeline.value }} \


### PR DESCRIPTION
### Summary

Run component validation pipelines from an isolated `commit-validation` branch instead of `master`, so validating pinned commits does not affect downstream pipelines that download artifacts from most recent master runs.

### Changes

- Add a `validationBranch` parameter with a default of `commit-validation` and reject empty or `master` values.
- Resolve each Azure DevOps pipeline's GitHub repository, then create or force-update the validation branch at the exact pinned commit before queueing the pipeline.
- Queue component pipelines with both the pinned commit SHA and `refs/heads/<validationBranch>`.
- Add prerequisite build-environment pipelines and a VS build stage before the existing dependency-ordered submodule stages.
- Add a reusable GitHub API helper for safely creating or updating validation branches.
- Publish each job's commit record from an isolated temporary directory to avoid artifact contamination between jobs.
- Update the pipeline documentation for the validation-branch workflow and required GitHub permissions.
