### PR TITLE
Add code sync branch exclusions

### DIFF
--- a/azure-pipelines/codesync-msft.yml
+++ b/azure-pipelines/codesync-msft.yml
@@ -32,6 +32,10 @@ steps:
       pushd sonic-buildimage-msft
       [ -z "$branches" ] && exit 1
       for branch in $branches; do
+        if [[ ",${SKIP_BRANCHES//[[:space:]]/}," == *",$branch,"* ]]; then
+          echo "======Skipping code sync for $branch======"
+          continue
+        fi
         branch_base=$branch
         branch_head=$branch
         remote=head


### PR DESCRIPTION
Add `SKIP_BRANCHES` filtering to bypass configured code-sync branches.